### PR TITLE
Adding download progress report

### DIFF
--- a/download.go
+++ b/download.go
@@ -75,10 +75,10 @@ type DownloadLocations struct {
 }
 
 type DownloadProgress struct {
-	LocationsToDownload []string                           `json:"locations_to_download"`
-	DownloadedFiles     int                                `json:"downloaded_files"`
-	LocationDetails     map[string]*DownloadLocationDetail `json:"location_details"`
 	TotalFiles          int                                `json:"total_files"`
+	DownloadedFiles     int                                `json:"downloaded_files"`
+	LocationsToDownload []string                           `json:"locations_to_download"`
+	LocationDetails     map[string]*DownloadLocationDetail `json:"location_details"`
 }
 
 type DownloadLocationDetail struct {
@@ -102,11 +102,13 @@ func DownloadIfTriggered() {
 		loge(err)
 
 		progress.LocationsToDownload = append(locations.Nations, locations.States...)
-		progress.TotalFiles = countTotalFiles(locations)
+		progress.TotalFiles = countTotalFiles(progress.LocationsToDownload)
 
 		for _, locationName := range progress.LocationsToDownload {
 			if _, ok := progress.LocationDetails[locationName]; !ok {
-				progress.LocationDetails[locationName] = &DownloadLocationDetail{}
+				progress.LocationDetails[locationName] = &DownloadLocationDetail{
+					TotalFiles: countTotalFiles([]string{locationName}),
+				}
 			}
 		}
 
@@ -262,9 +264,8 @@ func countFilesForBounds(bounds Bounds) int {
 	return ((maxLat - minLat) / GROUP_AREA_BOX_DEGREES) * ((maxLon - minLon) / GROUP_AREA_BOX_DEGREES)
 }
 
-func countTotalFiles(locations DownloadLocations) int {
+func countTotalFiles(allLocations []string) int {
 	totalFiles := 0
-	allLocations := append(locations.Nations, locations.States...)
 
 	for _, location := range allLocations {
 		if lData, ok := NATION_BOXES[location]; ok {

--- a/params.go
+++ b/params.go
@@ -21,7 +21,7 @@ var LAST_GPS_POSITION = ParamPath("LastGPSPosition", true)
 var LAST_GPS_POSITION_PERSIST = ParamPath("LastGPSPosition", false)
 var DOWNLOAD_BOUNDS = ParamPath("OSMDownloadBounds", true)
 var DOWNLOAD_LOCATIONS = ParamPath("OSMDownloadLocations", true)
-var DOWNLOAD_PROGRESS = ParamPath("OSMDownloadProgress", true)
+var DOWNLOAD_PROGRESS = ParamPath("OSMDownloadProgress", false)
 
 // exists returns whether the given file or directory exists
 func Exists(path string) (bool, error) {

--- a/params.go
+++ b/params.go
@@ -21,6 +21,7 @@ var LAST_GPS_POSITION = ParamPath("LastGPSPosition", true)
 var LAST_GPS_POSITION_PERSIST = ParamPath("LastGPSPosition", false)
 var DOWNLOAD_BOUNDS = ParamPath("OSMDownloadBounds", true)
 var DOWNLOAD_LOCATIONS = ParamPath("OSMDownloadLocations", true)
+var DOWNLOAD_PROGRESS = ParamPath("OSMDownloadProgress", true)
 
 // exists returns whether the given file or directory exists
 func Exists(path string) (bool, error) {


### PR DESCRIPTION
I am trying to add a simple download progress info... 

on my testing, I've passed multiple locations and states

```sh
echo '{ "nations": ["ES"], "states": ["CA","FL"] }' > dev/shm/params/d/OSMDownloadLocations
``` 

```json
{ 
  "nations": ["ES"], 
  "states": ["CA","FL"] 
}
```

And the resulting `dev/shm/params/d/OSMDownloadProgress` looks like the following: 
```json
{
  "total_files": 852,
  "downloaded_files": 2,
  "locations_to_download": [
    "ES",
    "CA",
    "FL"
  ],
  "location_details": {
    "CA": {
      "location_total_files": 801,
      "location_downloaded_files": 0
    },
    "ES": {
      "location_total_files": 35,
      "location_downloaded_files": 2
    },
    "FL": {
      "location_total_files": 16,
      "location_downloaded_files": 0
    }
  }
}
```

This should allow external integrations to track the progress