### PR TITLE
build docker images for releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,6 +26,8 @@ jobs:
         uses: actions/checkout@v3
       - name: Build Release Binary (arm64 for comma device)
         run: earthly --push +build-release
+      - name: Build Release Docker Images
+        run: earthly --push +docker-all-archs
       - name: Create Release
         uses: softprops/action-gh-release@v1
         if: startsWith(github.ref, 'refs/tags/')

--- a/Earthfile
+++ b/Earthfile
@@ -76,9 +76,13 @@ build-release:
     BUILD --platform=linux/arm64 +build
 
 docker:
+    FROM ubuntu:latest
+    WORKDIR /app
     COPY +build/mapd .
     COPY scripts/*.sh .
-    CMD ["./download_generate_and_update_planet.sh"]
+    RUN apt update
+    RUN apt install rclone wget osmium-tool -y
+    CMD ["./docker_entry.sh"]
     SAVE IMAGE --push openpilot-mapd:latest
 
 docker-all-archs:

--- a/Earthfile
+++ b/Earthfile
@@ -74,3 +74,13 @@ compile-capnp:
 
 build-release:
     BUILD --platform=linux/arm64 +build
+
+docker:
+    COPY +build/mapd .
+    COPY scripts/*.sh .
+    CMD ["./download_generate_and_update_planet.sh"]
+    SAVE IMAGE --push openpilot-mapd:latest
+
+docker-all-archs:
+    BUILD --platform=linux/arm64 +docker
+    BUILD --platform=linux/amd64 +docker

--- a/scripts/docker_entry.sh
+++ b/scripts/docker_entry.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+./generate_rclone_config.sh
+./download_generate_and_update_planet.sh

--- a/scripts/download_generate_and_update_planet.sh
+++ b/scripts/download_generate_and_update_planet.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+wget https://download.bbbike.org/osm/planet/planet-daily.osm.pbf
+
+./generate_and_update_planet.sh
+

--- a/scripts/download_generate_and_update_planet.sh
+++ b/scripts/download_generate_and_update_planet.sh
@@ -3,4 +3,3 @@
 wget https://download.bbbike.org/osm/planet/planet-daily.osm.pbf
 
 ./generate_and_update_planet.sh
-

--- a/scripts/filter_planet.sh
+++ b/scripts/filter_planet.sh
@@ -1,2 +1,2 @@
 #!/bin/bash
-osmium tags-filter planet-latest.osm.pbf "nw/highway=motorway,trunk,primary,secondary,tertiary,unclassified,residential,motorway_link,trunk_link,primary_link,secondary_link,tertiary_link" -o filtered.osm.pbf --overwrite
+osmium tags-filter planet-daily.osm.pbf "nw/highway=motorway,trunk,primary,secondary,tertiary,unclassified,residential,motorway_link,trunk_link,primary_link,secondary_link,tertiary_link" -o filtered.osm.pbf --overwrite

--- a/scripts/generate_and_update_planet.sh
+++ b/scripts/generate_and_update_planet.sh
@@ -23,6 +23,7 @@ do
     ./mapd --generate --minlat $j --minlon $i --maxlat $max_lat --maxlon $max_lon
     ./compress_offline.sh
     ./upload_offline.sh
+    ./upload_small_offline.sh
     rm -r offline
   done
 

--- a/scripts/generate_and_update_planet.sh
+++ b/scripts/generate_and_update_planet.sh
@@ -4,11 +4,6 @@ MIN_LAT=-90
 MAX_LON=180
 MAX_LAT=90
 
-cd ..
-earthly +build
-cp build/mapd scripts/
-cd scripts
-
 ./filter_planet.sh
 
 for (( i = $MIN_LON; i < $MAX_LON; i += 20 )) 

--- a/scripts/generate_rclone_config.sh
+++ b/scripts/generate_rclone_config.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+mkdir -p ~/.config/rclone
+
+cat > ~/.config/rclone/rclone.conf <<- EOM
+[r2]
+type = s3
+provider = Cloudflare
+access_key_id = $ACCESS_KEY_ID
+secret_access_key = $SECRET_ACCESS_KEY
+region = auto
+endpoint = $ENDPOINT
+acl = private
+EOM

--- a/scripts/upload_small_offline.sh
+++ b/scripts/upload_small_offline.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+rclone copy offline r2:osm-map-data/offline/ --progress --transfers 128 --checkers 128 --exclude **/*.tar.gz


### PR DESCRIPTION
creates docker images for downloading and updating maps. This will make automating a scheduled download and update easier.