### PR TITLE
Avoid allocating global offline area grid

### DIFF
--- a/maps/generate_offline.go
+++ b/maps/generate_offline.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"math"
 	"os"
 	"runtime"
 	"strconv"
@@ -89,18 +90,26 @@ func CreateBoundsDir(a Area, s OfflineSettings) error {
 	return errors.Wrap(err, "could not create bounds directory")
 }
 
+const (
+	latitudeAreas  = int(180 / ms.AREA_BOX_DEGREES)
+	longitudeAreas = int(360 / ms.AREA_BOX_DEGREES)
+)
+
+func areaBox(latitudeIndex int, longitudeIndex int) m.Box {
+	minLatitude := -90 + float64(latitudeIndex)*ms.AREA_BOX_DEGREES
+	minLongitude := -180 + float64(longitudeIndex)*ms.AREA_BOX_DEGREES
+	return m.Box{
+		MinPos: m.NewPosition(minLatitude, minLongitude),
+		MaxPos: m.NewPosition(minLatitude+ms.AREA_BOX_DEGREES, minLongitude+ms.AREA_BOX_DEGREES),
+	}
+}
+
 // Generates bounding boxes for storing ways
 func generateAreas() []Area {
-	areas := make([]Area, int((361/ms.AREA_BOX_DEGREES)*(181/ms.AREA_BOX_DEGREES)))
-	index := 0
-	for i := float64(-90); i < 90; i += ms.AREA_BOX_DEGREES {
-		for j := float64(-180); j < 180; j += ms.AREA_BOX_DEGREES {
-			a := &areas[index]
-			a.Box = m.Box{
-				MinPos: m.NewPosition(i, j),
-				MaxPos: m.NewPosition(i+ms.AREA_BOX_DEGREES, j+ms.AREA_BOX_DEGREES),
-			}
-			index += 1
+	areas := make([]Area, latitudeAreas*longitudeAreas)
+	for i := range latitudeAreas {
+		for j := range longitudeAreas {
+			areas[i*longitudeAreas+j].Box = areaBox(i, j)
 		}
 	}
 	return areas
@@ -333,42 +342,42 @@ func GenerateOffline(s OfflineSettings) {
 	slog.Info("Done Generating Offline Map")
 }
 
-var AREAS = generateAreas()
+func areaForPosition(pos m.Position) (Area, bool) {
+	latitude := pos.Lat()
+	longitude := pos.Lon()
+	if math.IsNaN(latitude) || math.IsNaN(longitude) ||
+		latitude < -90 || latitude > 90 || longitude < -180 || longitude > 180 {
+		return Area{}, false
+	}
+
+	latitudeIndex := int(math.Ceil(latitude/ms.AREA_BOX_DEGREES)) + latitudeAreas/2 - 1
+	longitudeIndex := int(math.Ceil(longitude/ms.AREA_BOX_DEGREES)) + longitudeAreas/2 - 1
+	if latitudeIndex < 0 {
+		latitudeIndex = 0
+	}
+	if longitudeIndex < 0 {
+		longitudeIndex = 0
+	}
+
+	return Area{Box: areaBox(latitudeIndex, longitudeIndex)}, true
+}
 
 func FindWaysAroundPosition(pos m.Position) (Offline, error) {
-	for _, area := range AREAS {
-		inBox := area.Box.PosInside(pos)
-		if inBox {
-			boundsName := GenerateBoundsFileName(area, DEFAULT_SETTINGS)
-			slog.Info("Loading bounds file", "filename", boundsName)
-			data, err := os.ReadFile(boundsName)
-			o := ReadOffline(data)
-			if !o.Loaded {
-				area := Area{}
-				areas := generateAreas()
-				for _, a := range areas {
-					if a.Box.PosInside(pos) {
-						area = a
-					}
-				}
-				o.box.Set(area.Box)
-			}
-			return o, errors.Wrap(err, "could not read current offline data file")
-		}
+	area, found := areaForPosition(pos)
+	if !found {
+		cBox := utils.Curry[m.Box]{}
+		cBox.Set(area.Box)
+		return Offline{Loaded: false, box: cBox}, nil
 	}
-	area := Area{}
-	areas := generateAreas()
-	for _, a := range areas {
-		if a.Box.PosInside(pos) {
-			area = a
-		}
+
+	boundsName := GenerateBoundsFileName(area, DEFAULT_SETTINGS)
+	slog.Info("Loading bounds file", "filename", boundsName)
+	data, err := os.ReadFile(boundsName)
+	o := ReadOffline(data)
+	if !o.Loaded {
+		o.box.Set(area.Box)
 	}
-	cBox := utils.Curry[m.Box]{}
-	cBox.Set(area.Box)
-	return Offline{
-		Loaded: false,
-		box:    cBox,
-	}, nil
+	return o, errors.Wrap(err, "could not read current offline data file")
 }
 
 func ParseMaxSpeed(maxspeed string) float64 {


### PR DESCRIPTION
## Summary

- Replace the package-level `AREAS = generateAreas()` allocation with an O(1) coordinate-to-area calculation.
- Reuse the calculated area for the offline tile path and unloaded fallback box.
- Derive the generation grid and runtime lookup from the same `areaBox(latitudeIndex, longitudeIndex)` helper.

## Motivation

Importing the `maps` package currently creates a global slice containing 1,045,456 `Area` values before the first tile lookup. On a 64-bit build, each `Area` is 56 bytes, so the slice accounts for 55.83 MiB before considering other process memory.

`FindWaysAroundPosition` then linearly scans that slice to locate one 0.25-degree tile. If a tile cannot be loaded, the old implementation allocates another 55.83 MiB slice, constructs the complete grid again, and rescans the entire slice for the fallback box.

That fallback is hit more often than tile crossings alone would suggest. The main loop re-enters `FindWaysAroundPosition` whenever `len(state.Data.Ways()) == 0`, and that condition stays true for as long as no tile loads. On a device without tiles downloaded for the current area, the old path therefore ran on every GPS fix inside a loop with a 50 ms delay.

This change calculates the same tile directly from latitude and longitude while preserving the existing first-match behavior at exact tile boundaries.

## Memory impact

<img width="1400" height="900" alt="mapd-memory-comparison" src="https://github.com/user-attachments/assets/32fb51b0-1ecb-42c6-b741-a6756abe810a" />

[mapd-memory-raw.csv](https://github.com/user-attachments/files/30820492/mapd-memory-raw.csv)

| Metric | Baseline (`68813e0`) | Optimized (`ad3c618`) | Difference |
|---|---:|---:|---:|
| Mean PSS | 63.67 +/- 0.04 MiB | 8.17 +/- 0.05 MiB | **-55.50 MiB (87.2%)** |
| Mean Go heap allocation | 56.01 MiB | 0.17 MiB | **-55.84 MiB** |
| Expected removed slice | - | - | 1,045,456 x 56 bytes = **55.83 MiB** |

The PSS values are reported as mean +/- sample standard deviation.

Benchmark methodology:

- Go 1.25.1 on Linux/amd64.
- The same isolated probe imported `pfeifer.dev/mapd/maps`, forced `runtime.GC()` and `debug.FreeOSMemory()`, and then remained idle.
- Ten process launches per commit using a repeated ABBA ordering to reduce ordering bias.
- PSS was read from `/proc/<pid>/smaps_rollup`; Go heap values came from `runtime.MemStats`.
- This isolates package-initialization cost rather than simulating a full on-road workload.

The measurements were collected at optimized commit `ad3c618`. Final commit `6b8c3ea` preserves the same package-initialization behavior; its additional changes share the area-box calculation and size the offline generation grid exactly.

The runtime lookup changes from a linear scan of up to 1,045,456 boxes to constant-time arithmetic, and the fallback grid allocation is removed entirely.

## Correctness fixes

Three latent defects fall out of the rewrite:

- **Boundary inconsistency in the unloaded fallback.** The old fallback rescan had no `break`, so the last matching area won, while the filename it had just attempted came from the first match. On an exact 0.25-degree boundary, the fallback box could therefore disagree with the attempted tile path. The new code uses the same calculated area for both.
- **Degenerate box at (0, 0).** `make([]Area, int((361/0.25)*(181/0.25)))` over-allocated 8,656 slots beyond the 1,036,800 real cells. Those trailing zero-value `Area`s have box `(0,0)-(0,0)`, and the last-match rescan selected one of them at exactly `(0, 0)`.
- **Junk tile during generation.** `GenerateOffline` iterated the whole slice, so generating a region containing the origin could write a degenerate `offline/0/0/0.000000_0.000000_0.000000_0.000000` tile. Sizing the slice to `latitudeAreas * longitudeAreas` removes those slots.

## Validation

A temporary comparison harness was used for focused and exhaustive validation without adding test-only code to this commit:

- Checked values immediately below, exactly on, and immediately above every internal latitude and longitude tile boundary: 6,474 boundary assertions passed.
- Compared old and new resolved tile filenames and found/not-found results across 2,275,789 positions: 1,036,800 cell centres, 1,038,961 grid corners, 200,000 deterministic random fixes, and 28 world-edge or invalid-coordinate cases. There were zero differences.
- Confirmed `generateAreas()` is bit-identical to the previous implementation across all 1,036,800 real cells; the 8,656 removed slots were all zero-valued.
- Confirmed the centre of every generated cell resolves back to that same cell through `areaForPosition`.
- Checked ordinary coordinates, world edges, poles, datelines, NaN, and positive and negative infinity.
- Confirmed the `math.IsNaN` guard is required: NaN fails both range comparisons, and converting the result of `math.Ceil(NaN)` to an integer is implementation-dependent.
- `go test ./...` and `go vet ./...` passed for the final source on Linux/amd64 with Go 1.25.1.

## Compatibility

- No offline map file-format changes.
- No changes to the naming format or any valid tile path; only the degenerate zero-area artifact is no longer generated.
- No new dependencies.
- `generateAreas()` remains available for offline map generation and now uses the shared `areaBox` helper.
- The unloaded fallback box now remains consistent with the area used to select the tile filename.
- For non-power-of-two `AREA_BOX_DEGREES` values, repeated addition and indexed multiplication can round differently. Generation and lookup now derive bounds through the same helper.
- `AREAS` was exported. Nothing in this repository referenced it, but removing it is a package-level API change for any external consumer that did.
