### PR TITLE
Load the built image before extracting release artifacts

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,13 +2,13 @@ build: capnp go-deps
 	go build -ldflags="-extldflags=-static -s -w" -o build/mapd
 
 docker:
-	docker buildx build --platform linux/arm64 . -t pfeiferj/mapd:latest
+	docker buildx build --platform linux/arm64 --load . -t pfeiferj/mapd:latest
 
 dockerx86:
 	docker buildx build --platform linux/amd64 . -t pfeiferj/mapd:latest
 
 release: docker
-	docker run --platform linux/arm64 -v ./build:/build pfeiferj/mapd:latest cp mapd /build/mapd
+	docker run --pull=never --platform linux/arm64 -v ./build:/build pfeiferj/mapd:latest cp mapd /build/mapd
 
 
 format:

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ docker:
 	docker buildx build --platform linux/arm64 --load . -t pfeiferj/mapd:latest
 
 dockerx86:
-	docker buildx build --platform linux/amd64 . -t pfeiferj/mapd:latest
+	docker buildx build --platform linux/amd64 --load . -t pfeiferj/mapd:latest
 
 release: docker
 	docker run --pull=never --platform linux/arm64 -v ./build:/build pfeiferj/mapd:latest cp mapd /build/mapd


### PR DESCRIPTION
## Summary

- Load the single-platform arm64 Buildx result into Docker before extracting `mapd`.
- Disable registry pulls during extraction so a missing local image fails the release instead of being substituted from the registry.
- Apply the same `--load` fix to `dockerx86`, which has the same defect but is not on the release path.

## Motivation

The artifact workflows configure Buildx with the `docker-container` driver, but the `docker` prerequisite of `make release` previously tagged the build without exporting it. With this driver, that leaves the result only in the BuildKit cache. The following `docker run` could not find the tag locally, so Docker's default pull policy fetched `pfeiferj/mapd:latest` and the workflow uploaded the binary copied from that registry image.

This happened in the successful build for `68813e0`: the log shows the cache-only warning, `Unable to find image ... locally`, a pull of `pfeiferj/mapd:latest`, and then the artifact upload.

Baseline evidence: [Actions run 30710638539](https://github.com/pfeiferj/mapd/actions/runs/30710638539)

`--load` is Buildx's shorthand for exporting the result to the local Docker image store. `--pull=never` makes extraction fail if that image is absent.

Docker references: [Build drivers](https://docs.docker.com/build/builders/drivers/), [`buildx build --load`](https://docs.docker.com/reference/cli/docker/buildx/build/#load), [`docker run --pull`](https://docs.docker.com/reference/cli/docker/container/run/#pull)

## Validation

| Check | Before | After |
|---|---|---|
| `docker-container` output | Cache-only warning; image absent | `importing to docker`; image present |
| Audit-only fresh-tag probe with `--pull=never` | Exit 125: no such image | Exit 0; expected marker returned |
| Application-image registry fallback | Pulled `pfeiferj/mapd:latest` | No missing-image or `pfeiferj/mapd` pull messages |
| Artifact workflow | Baseline Build run uploaded the registry-sourced binary | Release run uploaded the binary extracted from the locally loaded Buildx result |

The Release workflow passed for `d16ff77e081f9f97a2f0106bc4988638b1a7d796`, which was the branch head at the time of that run:

- [FrogAi Release run 31167702371](https://github.com/FrogAi/mapd/actions/runs/31167702371)
- Buildx logged `importing to docker`.
- Extraction ran with `docker run --pull=never`.
- The log contains no cache-only warning, missing-application-image message, or pull of `pfeiferj/mapd`.
- Artifact `8990042404` uploaded successfully; GitHub reports archive SHA-256 `2b3e6b66ea0d27480a06b4f6c1ba90f31371566ccaf30469a5d6014dd87096d3`.
- A locally downloaded copy contains a 21,407,248-byte `mapd` binary. Its build information reports module `pfeifer.dev/mapd`, Go 1.25.1, `GOOS=linux`, and `GOARCH=arm64`.
- Binary SHA-256: `44f657d634672dfa34e3209ca84f230c7fb4c32ba0448c63f20a2a4af0f59968`.

Additional local audit checks (not part of Actions run `31167702371`; logs are not attached to this PR):

- `go test ./...` passed in Linux with Go 1.25.1 and the required zlib headers.
- `go vet ./...` passed in the same environment.
- `git diff --check` passed.
- A Linux GNU Make dry run emitted the intended `--load` and `--pull=never` commands.

The driver regression probe was audit-only and is not included in this PR.

## Compatibility

This keeps the existing Dockerfile, arm64 platform, image name, QEMU setup, workflow conditions, and `build/mapd` artifact path. The release build remains single-platform, which is supported by the Docker image-store exporter used by `--load`.

This deliberately changes `make docker` under non-default Buildx drivers: the completed arm64 image is now imported into the local Docker image store.

`dockerx86` receives the same `--load` change. It has the same defect, but it is not part of the release path, so this is preventative rather than a fix to observed behavior. It is not covered by Actions run `31167702371`, which predates that commit.

The intentional CI behavior change is fail-closed extraction: if `pfeiferj/mapd:latest` is absent from the runner's local image store, extraction now fails rather than pulling the application image from a registry.

## Scope and limitations

On a clean workflow runner, this establishes that extraction uses the Buildx result just loaded by this run. It does not make the build hermetic or reproducible, embed a Git revision in the binary, or prevent normal build-time dependency and base-image downloads.

The test and vet commands above are supporting validation, not new CI gates. Adding pre-publication test/vet policy is a separate change with its own runtime and workflow design.
