### PR TITLE
Gate release artifacts on test and vet

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,6 +13,27 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v5
 
+      - name: Set up Go
+        if: github.event_name == 'pull_request' || github.ref == 'refs/heads/main'
+        uses: actions/setup-go@v7
+        with:
+          go-version-file: go.mod
+          cache-dependency-path: go.sum
+
+      - name: Install test dependencies
+        if: github.event_name == 'pull_request' || github.ref == 'refs/heads/main'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends zlib1g-dev
+
+      - name: Test
+        if: github.event_name == 'pull_request' || github.ref == 'refs/heads/main'
+        run: go test ./...
+
+      - name: Vet
+        if: github.event_name == 'pull_request' || github.ref == 'refs/heads/main'
+        run: go vet ./...
+
       - name: Set up QEMU (arm64 emulation)
         uses: docker/setup-qemu-action@v3
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,6 +13,23 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v5
 
+      - name: Set up Go
+        uses: actions/setup-go@v7
+        with:
+          go-version-file: go.mod
+          cache-dependency-path: go.sum
+
+      - name: Install test dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends zlib1g-dev
+
+      - name: Test
+        run: go test ./...
+
+      - name: Vet
+        run: go vet ./...
+
       - name: Set up QEMU (arm64 emulation)
         uses: docker/setup-qemu-action@v3
 


### PR DESCRIPTION
## Summary

- Run the existing test suite and vet checks before artifact builds in both GitHub Actions workflows.
- Install the zlib development headers required to compile the existing `czlib` dependency during those native checks.
- Apply validation only to artifact-producing Build paths; leave non-artifact Build paths unchanged.

## Root cause and motivation

The artifact-producing paths in the Build and Release workflows proceeded from checkout through QEMU and Buildx setup to the arm64 release build and upload without running `go test ./...` or `go vet ./...`. An artifact could therefore be published without those existing repository checks being evaluated.

## Implementation

Both workflows now set up the Go version declared by `go.mod` for the native test and vet steps, install `zlib1g-dev`, and run those checks before QEMU, Buildx, the release build, and upload. In the Build workflow, the new steps use the same condition as the existing release and upload steps. The Release workflow runs them unconditionally because every invocation produces an artifact.

## Validation

The [exact-head Release run](https://github.com/FrogAi/mapd/actions/runs/31170463277) completed successfully for commit `7a40834c3cb79666a69260041ff905271bf0522a`:

| Step | Result | Duration |
|---|---|---:|
| Set up Go | Pass | 9s |
| Install test dependencies | Pass | 5s |
| Test | Pass | 34s |
| Vet | Pass | 3s |
| Set up QEMU | Pass | 9s |
| Set up Buildx | Pass | 4s |
| Build release binary | Pass | 13m 27s |
| Upload release binary | Pass | 2s |

The four new pre-build steps occupied 51 seconds in this cache-miss Release run, before the arm64 build and artifact upload.

Additional checks:

- `git diff --check`: pass.
- actionlint v1.7.12 on both changed workflows: pass.
- Structural YAML audit of step order and conditions: pass.
- `go test ./...` and `go vet ./...` in a clean Debian 12 container with Go 1.25.1 and `zlib1g-dev`: pass.
- Negative control without `zlib1g-dev`: both commands stop at the missing zlib `pkg-config` dependency.

## Compatibility

This changes only the two GitHub Actions workflow files. It does not change application code, APIs, file formats, `go.mod`, `go.sum`, the release commands, or the artifact path. Non-artifact Build paths continue to run the existing `make build` path without the publication-only validation steps.

## Limitations

This reuses the repository's existing tests and does not add new coverage. The exact-head run demonstrates successful execution and ordering of the Release gates, but it does not deliberately inject a failing test or vet result. The artifact-producing Build conditions were structurally audited but were not runtime-exercised by this run.

The run still exhibited the cache-only/registry-fallback behavior addressed separately by #98: it pulled `pfeiferj/mapd:latest` before upload. It proves gate execution and ordering only; it does not show that the uploaded binary came from this commit's Buildx result.
