### PR TITLE
Use peak lateral acceleration magnitude for vision curves

### DIFF
--- a/vision_curve.go
+++ b/vision_curve.go
@@ -34,7 +34,7 @@ func calcVisionCurveSpeed(model log.ModelDataV2, state *State) float32 {
 	}
 
 	for i := range zOrientRate.Len() {
-		predictedLatAccels[i] = zOrientRate.At(i) * xVelocity.At(i)
+		predictedLatAccels[i] = float32(math.Abs(float64(zOrientRate.At(i) * xVelocity.At(i))))
 		if predictedLatAccels[i] > maxLatA {
 			maxLatA = predictedLatAccels[i]
 		}


### PR DESCRIPTION
## Summary

- Compare predicted lateral acceleration by magnitude when selecting the peak used for vision curve speed.
- Make equal-magnitude left and right curves produce the same target while preserving the existing speed bounds and smoothing.

## Root cause and motivation

`calcVisionCurveSpeed` multiplies each predicted yaw rate by its corresponding longitudinal velocity, but the existing maximum starts at zero and compares the signed products directly. A horizon containing only finite negative lateral acceleration therefore leaves the peak at zero and reaches the 90 mph ceiling instead of producing the same target as the equal-magnitude positive curve.

The published vision curve speed is a scalar target with no directional meaning, so turn direction should not affect the selected peak severity.

## Implementation

Take the absolute value of each predicted lateral acceleration before the existing maximum comparison. This changes one expression in the calculation and leaves the current curvature conversion, minimum target, 90 mph ceiling, and 20-sample moving average unchanged.

## Validation

An audit-only Go test built real Cap'n Proto `ModelDataV2` messages and called `calcVisionCurveSpeed` directly. The harness is not included in this commit.

| Model horizon | Base `68813e0` | Candidate `e6924c4` |
|---|---:|---:|
| `+0.05 rad/s` at 20 m/s | 27.568098 m/s | 27.568098 m/s |
| `-0.05 rad/s` at 20 m/s | 40.232452 m/s | 27.568098 m/s |
| `+0.02, -0.06, +0.04 rad/s` at 20 m/s | 30.822071 m/s | 25.166115 m/s |
| Sign-inverted five-frame sequence | Diverged | Equal after every frame |

The base fails the direction-symmetry and moving-average assertions while passing the preservation checks. The candidate passes the focused suite for 100 consecutive repetitions.

Additional candidate checks on Linux/amd64 with Go 1.25.1 and `zlib1g-dev`:

- `go test ./...`: pass.
- `go vet ./...`: pass.
- `go build ./...`: pass.
- `git diff --check`: pass.
- [Exact-head FrogAi Build run](https://github.com/FrogAi/mapd/actions/runs/31173494267): pass in 53 seconds.

## Compatibility

This changes one expression in `vision_curve.go`. It does not change schemas, settings, APIs, dependencies, output fields, speed bounds, or smoothing. Positive-only, straight/zero, minimum-speed, maximum-speed, empty-paired-list, and extra-velocity-sample checks retain their previous results.

## Limitations

Validation covers mapd's documented output contract; it does not establish downstream integration, device enablement, or on-road frequency.
