### PR TITLE
Reject directionally illegal route fallbacks

### DIFF
--- a/maps/way.go
+++ b/maps/way.go
@@ -779,6 +779,16 @@ func (w *Way) NextWay(offlineMaps *Offline, isForward bool) (NextWayResult, erro
 		return NextWayResult{StartPosition: matchNode}, errors.Wrap(err, "could not check for next ways")
 	}
 
+	legalWays := []Way{}
+	for _, mWay := range matchingWays {
+		isForward := mWay.IsForwardFrom(matchNode)
+		if !isForward && mWay.OneWay() {
+			continue
+		}
+		legalWays = append(legalWays, mWay)
+	}
+	matchingWays = legalWays
+
 	if len(matchingWays) == 0 {
 		return NextWayResult{StartPosition: matchNode}, nil
 	}
@@ -812,11 +822,6 @@ func (w *Way) NextWay(offlineMaps *Offline, isForward bool) (NextWayResult, erro
 		for _, mWay := range matchingWays {
 			mName := mWay.WayName()
 			if mName == name {
-				isForward := mWay.IsForwardFrom(matchNode)
-				if !isForward && mWay.OneWay() {
-					continue
-				}
-
 				if len(nodes) > 1 && mWay.isValidConnection(matchNode, matchBearingNode, curvatureThreshold) {
 					candidates = append(candidates, mWay)
 				}
@@ -842,11 +847,6 @@ func (w *Way) NextWay(offlineMaps *Offline, isForward bool) (NextWayResult, erro
 		for _, mWay := range matchingWays {
 			mRef := mWay.WayRef()
 			if mRef == ref {
-				isForward := mWay.IsForwardFrom(matchNode)
-				if !isForward && mWay.OneWay() {
-					continue
-				}
-
 				if len(nodes) > 1 && mWay.isValidConnection(matchNode, matchBearingNode, curvatureThreshold) {
 					candidates = append(candidates, mWay)
 				}
@@ -879,11 +879,6 @@ func (w *Way) NextWay(offlineMaps *Offline, isForward bool) (NextWayResult, erro
 				}
 			}
 			if hasMatch {
-				isForward := mWay.IsForwardFrom(matchNode)
-				if !isForward && mWay.OneWay() {
-					continue
-				}
-
 				if len(nodes) > 1 && mWay.isValidConnection(matchNode, matchBearingNode, curvatureThreshold) {
 					candidates = append(candidates, mWay)
 				}
@@ -905,10 +900,6 @@ func (w *Way) NextWay(offlineMaps *Offline, isForward bool) (NextWayResult, erro
 
 	validWays := []Way{}
 	for _, mWay := range matchingWays {
-		isForward := mWay.IsForwardFrom(matchNode)
-		if !isForward && mWay.OneWay() {
-			continue
-		}
 		if len(nodes) > 1 && mWay.isValidConnection(matchNode, matchBearingNode, curvatureThreshold) {
 			validWays = append(validWays, mWay)
 		}


### PR DESCRIPTION
## Summary

- Establish directional legality immediately after `MatchingWays`.
- Apply freeway, name, ref, curvature, and fallback heuristics only to the legal subset.
- When the in-bounds matching set contains no legal continuation, return the existing no-way result with `StartPosition` at the junction.
- Preserve the fallback that allows legal sharp turns when every candidate exceeds the curvature threshold.

## Motivation

`NextWay` already rejected reverse one-way candidates in its preferred and generic candidate paths, but the final fallback returned raw `matchingWays[0]`. The audit's two-road fixture therefore returned way 2 with `IsForward=false` even though leaving the junction required reversing along a one-way road.

That impossible predicted path can feed recursive route prediction, upcoming speed-limit, advisory-speed, and hazard scans, curve generation, and extended path output.

Legality must be established before the soft heuristics. Filtering only the final fallback is insufficient: on freeways, an illegal preferred non-service road can make the freeway filter discard the only legal service or access alternative before fallback.

## Behavior

| Topology | Base `68813e05` | Head `de30289` |
|---|---|---|
| Illegal one-way only | Returns way 2 in reverse | No way; preserves junction `StartPosition` |
| Illegal first, legal straight alternative | Returns legal way 3 | Unchanged |
| Legal sharp-turn only | Returns sharp way 4 through fallback | Unchanged |
| Illegal first, legal sharp turn | Returns illegal way 2 | Returns legal way 4 |
| Reverse two-way candidate | Returns way 5 in reverse | Unchanged |
| Same-ID continuation with a distinct bounding box and continuation segment | Returns the continuation | Unchanged |
| Reverse-current continuation | Returns the candidate from the active junction | Unchanged |
| True dead end | No way; preserves junction `StartPosition` | Unchanged |
| Freeway illegal Main plus legal Service Road | Returns illegal Main | Returns legal Service Road |
| Two legal sharp turns | Returns the first legal candidate | Unchanged stable order |

The first row is the executed audit reproduction. The remaining rows are deterministic static source-path outcomes against Base and Head, not executed tests. Sharp-turn rows deliberately place the candidate above the active curvature threshold so they exercise the unchanged final fallback.

## Validation

- An audit-only fixture executed the baseline illegal-only reproduction: current road into junction J, sole one-way candidate encoded toward J, observed result way 2 in reverse instead of the no-way junction sentinel.
- Static topology review covered an illegal-only junction, a legal alternative, legal sharp turns, illegal-first ordering, reverse two-way travel, same-ID continuation, reverse-current traversal, a true dead end, the freeway hidden-alternative case, and stable fallback order.
- Static source review confirmed the filter is stable, matching errors still return before filtering, and all downstream selection heuristics operate on the legal subset.
- [Fork Build #15](https://github.com/FrogAi/mapd/actions/runs/31283499047) passed the `make build` job on exact commit `de30289`.

## Compatibility

- No schema, settings, or offline-map format changes.
- Reverse traversal remains allowed on two-way roads.
- Freeway, name, ref, curvature thresholds, ranking, and fallback order are unchanged among the remaining legal candidates.
- The no-way junction sentinel and nil-error dead-end contract are unchanged.
- Generator one-way parsing is unchanged and remains isolated in the next F-04 PR.
- `NextWays` and downstream consumer implementations and interfaces are unchanged; they now receive only legal continuations or the no-way sentinel.
- Explicitly one-way closed ways (first node identical to last node, e.g. roundabout rings tagged `oneway=yes`) are rejected at their repeated endpoint by the now-universal filter for as long as `IsForwardFrom` classifies that match as reverse; [PR #105](https://github.com/pfeiferj/mapd/pull/105)'s closed-way clause restores forward classification there. Land #105's runtime change with or before this one — a trial merge of both auto-merges cleanly, builds, and passes the full test suite, with #105's clause preventing this filter from discarding one-way roundabout rings.
