### PR TITLE
Track live input health and recover GPS failover

### DIFF
--- a/cereal/gps.go
+++ b/cereal/gps.go
@@ -2,29 +2,111 @@ package cereal
 
 import (
 	"log/slog"
+	"time"
 
 	"pfeifer.dev/mapd/cereal/log"
 	ms "pfeifer.dev/mapd/settings"
 )
 
+const (
+	gpsLocationExternalTimeout = time.Second
+	gpsLocationTimeout         = 10 * time.Second
+)
+
+type gpsSource uint8
+
+const (
+	gpsSourceNone gpsSource = iota
+	gpsSourceInternal
+	gpsSourceExternal
+)
+
+type gpsSample struct {
+	data       log.GpsLocationData
+	receivedAt time.Time
+	usable     bool
+}
+
+func (s gpsSample) Healthy(now time.Time, maxAge time.Duration) bool {
+	age := now.Sub(s.receivedAt)
+	return s.usable && age >= 0 && age < maxAge
+}
+
+func (s *gpsSample) Update(data log.GpsLocationData, status SubscriberStatus) {
+	s.receivedAt = status.ReceivedAt
+	s.usable = status.EventValid && (data.HasFix() || data.Flags()&1 != 0)
+	if s.usable {
+		s.data = data
+	}
+}
+
 type GpsSub struct {
-	gpsLocation         Subscriber[log.GpsLocationData]
-	gpsLocationExternal Subscriber[log.GpsLocationData]
-	useExt              bool
+	gpsLocation               Subscriber[log.GpsLocationData]
+	gpsLocationExternal       Subscriber[log.GpsLocationData]
+	gpsLocationSample         gpsSample
+	gpsLocationExternalSample gpsSample
+	now                       func() time.Time
+	source                    gpsSource
 }
 
 func (s *GpsSub) Read() (locationData log.GpsLocationData, success bool) {
-	if s.useExt {
-		return s.gpsLocationExternal.Read()
-	} else {
-		locationData, success = s.gpsLocationExternal.Read()
-		if success {
-			s.useExt = true
-			slog.Info("Found gpsLocationExternal, switching to external GPS provider")
-			return locationData, success
+	internalData, internalUpdated := s.gpsLocation.Read()
+	if internalUpdated {
+		s.gpsLocationSample.Update(internalData, s.gpsLocation.Status())
+	}
+
+	externalData, externalUpdated := s.gpsLocationExternal.Read()
+	if externalUpdated {
+		s.gpsLocationExternalSample.Update(externalData, s.gpsLocationExternal.Status())
+	}
+
+	now := s.nowTime()
+	source := gpsSourceNone
+	if s.gpsLocationExternalSample.Healthy(now, gpsLocationExternalTimeout) {
+		source = gpsSourceExternal
+	} else if s.gpsLocationSample.Healthy(now, gpsLocationTimeout) {
+		source = gpsSourceInternal
+	}
+
+	sourceChanged := source != s.source
+	if sourceChanged {
+		s.source = source
+		if source == gpsSourceExternal {
+			slog.Info("Switching to external GPS provider")
+		} else if source == gpsSourceInternal {
+			slog.Info("Switching to internal GPS provider")
 		}
 	}
-	return s.gpsLocation.Read()
+
+	switch source {
+	case gpsSourceExternal:
+		if externalUpdated && s.gpsLocationExternalSample.usable || sourceChanged {
+			return s.gpsLocationExternalSample.data, true
+		}
+	case gpsSourceInternal:
+		if internalUpdated && s.gpsLocationSample.usable || sourceChanged {
+			return s.gpsLocationSample.data, true
+		}
+	}
+	return locationData, false
+}
+
+func (s *GpsSub) Fresh(now time.Time) bool {
+	switch s.source {
+	case gpsSourceExternal:
+		return s.gpsLocationExternalSample.Healthy(now, gpsLocationExternalTimeout)
+	case gpsSourceInternal:
+		return s.gpsLocationSample.Healthy(now, gpsLocationTimeout)
+	default:
+		return false
+	}
+}
+
+func (s *GpsSub) nowTime() time.Time {
+	if s.now != nil {
+		return s.now()
+	}
+	return time.Now()
 }
 
 func (s *GpsSub) Close() {
@@ -36,6 +118,6 @@ func GetGpsSub() (gpsSub GpsSub) {
 	return GpsSub{
 		gpsLocation:         NewSubscriber("gpsLocation", GpsLocationReader, true, ms.Settings.SubscriberSettings.ShadowGpsLocation),
 		gpsLocationExternal: NewSubscriber("gpsLocationExternal", GpsLocationExternalReader, true, ms.Settings.SubscriberSettings.ShadowGpsLocationExternal),
-		useExt:              false,
+		now:                 time.Now,
 	}
 }

--- a/cereal/gps.go
+++ b/cereal/gps.go
@@ -11,6 +11,7 @@ import (
 const (
 	gpsLocationExternalTimeout = time.Second
 	gpsLocationTimeout         = 10 * time.Second
+	gpsExternalPromotionDelay  = 2 * time.Second
 )
 
 type gpsSource uint8
@@ -47,6 +48,7 @@ type GpsSub struct {
 	gpsLocationExternalSample gpsSample
 	now                       func() time.Time
 	source                    gpsSource
+	externalHealthySince      time.Time
 }
 
 func (s *GpsSub) Read() (locationData log.GpsLocationData, success bool) {
@@ -61,15 +63,9 @@ func (s *GpsSub) Read() (locationData log.GpsLocationData, success bool) {
 	}
 
 	now := s.nowTime()
-	source := gpsSourceNone
-	if s.gpsLocationExternalSample.Healthy(now, gpsLocationExternalTimeout) {
-		source = gpsSourceExternal
-	} else if s.gpsLocationSample.Healthy(now, gpsLocationTimeout) {
-		source = gpsSourceInternal
-	}
+	source := s.selectSource(now)
 
-	sourceChanged := source != s.source
-	if sourceChanged {
+	if source != s.source {
 		s.source = source
 		if source == gpsSourceExternal {
 			slog.Info("Switching to external GPS provider")
@@ -80,15 +76,34 @@ func (s *GpsSub) Read() (locationData log.GpsLocationData, success bool) {
 
 	switch source {
 	case gpsSourceExternal:
-		if externalUpdated && s.gpsLocationExternalSample.usable || sourceChanged {
+		if externalUpdated && s.gpsLocationExternalSample.usable {
 			return s.gpsLocationExternalSample.data, true
 		}
 	case gpsSourceInternal:
-		if internalUpdated && s.gpsLocationSample.usable || sourceChanged {
+		if internalUpdated && s.gpsLocationSample.usable {
 			return s.gpsLocationSample.data, true
 		}
 	}
 	return locationData, false
+}
+
+func (s *GpsSub) selectSource(now time.Time) gpsSource {
+	externalHealthy := s.gpsLocationExternalSample.Healthy(now, gpsLocationExternalTimeout)
+	internalHealthy := s.gpsLocationSample.Healthy(now, gpsLocationTimeout)
+	if externalHealthy {
+		if s.externalHealthySince.IsZero() {
+			s.externalHealthySince = now
+		}
+	} else {
+		s.externalHealthySince = time.Time{}
+	}
+	if externalHealthy && (s.source == gpsSourceExternal || !internalHealthy || now.Sub(s.externalHealthySince) >= gpsExternalPromotionDelay) {
+		return gpsSourceExternal
+	}
+	if internalHealthy {
+		return gpsSourceInternal
+	}
+	return gpsSourceNone
 }
 
 func (s *GpsSub) Fresh(now time.Time) bool {

--- a/cereal/subscriber.go
+++ b/cereal/subscriber.go
@@ -2,6 +2,7 @@ package cereal
 
 import (
 	"math"
+	"time"
 
 	"capnproto.org/go/capnp/v3"
 	"github.com/pfeiferj/gomsgq"
@@ -11,9 +12,22 @@ import (
 
 type Reader[T any] func(log.Event) (T, error)
 
+type SubscriberStatus struct {
+	EventValid bool
+	ReceivedAt time.Time
+	Seen       bool
+}
+
+func (s SubscriberStatus) Healthy(now time.Time, maxAge time.Duration) bool {
+	age := now.Sub(s.ReceivedAt)
+	return s.Seen && s.EventValid && age >= 0 && age < maxAge
+}
+
 type Subscriber[T any] struct {
 	Sub    gomsgq.MsgqSubscriber
+	now    func() time.Time
 	reader Reader[T]
+	status SubscriberStatus
 }
 
 func (s *Subscriber[T]) Read() (obj T, success bool) {
@@ -21,6 +35,7 @@ func (s *Subscriber[T]) Read() (obj T, success bool) {
 	if len(data) == 0 {
 		return obj, false
 	}
+	receivedAt := s.nowTime()
 	msg, err := capnp.Unmarshal(data)
 	if err != nil {
 		return obj, false
@@ -38,7 +53,23 @@ func (s *Subscriber[T]) Read() (obj T, success bool) {
 	if err != nil {
 		return obj, false
 	}
+	s.status = SubscriberStatus{
+		EventValid: event.Valid(),
+		ReceivedAt: receivedAt,
+		Seen:       true,
+	}
 	return obj, true
+}
+
+func (s *Subscriber[T]) Status() SubscriberStatus {
+	return s.status
+}
+
+func (s *Subscriber[T]) nowTime() time.Time {
+	if s.now != nil {
+		return s.now()
+	}
+	return time.Now()
 }
 
 func NewSubscriber[T any](name string, reader Reader[T], conflate bool, shadow bool) (subscriber Subscriber[T]) {
@@ -53,6 +84,7 @@ func NewSubscriber[T any](name string, reader Reader[T], conflate bool, shadow b
 	sub.Init(msgq)
 
 	subscriber.Sub = sub
+	subscriber.now = time.Now
 	subscriber.reader = reader
 	return subscriber
 }

--- a/extended_state.go
+++ b/extended_state.go
@@ -41,6 +41,14 @@ func (s *ExtendedState) setPosition(out custom.MapdExtendedOut) {
 }
 
 func (s *ExtendedState) setPath(out custom.MapdExtendedOut) {
+	if !s.state.GpsValid || !s.state.MapValid || !s.state.RouteValid {
+		_, err := out.NewPath(0)
+		if err != nil {
+			slog.Warn("failed to create path in extended state")
+		}
+		return
+	}
+
 	nodes := s.state.CurrentWay.Way.Nodes()
 	num_points := len(nodes)
 	all_nodes := [][]m.Position{nodes}

--- a/extended_state.go
+++ b/extended_state.go
@@ -41,7 +41,7 @@ func (s *ExtendedState) setPosition(out custom.MapdExtendedOut) {
 }
 
 func (s *ExtendedState) setPath(out custom.MapdExtendedOut) {
-	if !s.state.GpsValid || !s.state.MapValid || !s.state.RouteValid {
+	if !s.state.RouteUsable() {
 		_, err := out.NewPath(0)
 		if err != nil {
 			slog.Warn("failed to create path in extended state")

--- a/main.go
+++ b/main.go
@@ -13,9 +13,10 @@ import (
 )
 
 const (
-	mapLoadRetryDelay = time.Second
-	carStateTimeout   = 100 * time.Millisecond
-	modelV2Timeout    = 500 * time.Millisecond
+	mapLoadRetryDelay    = time.Second
+	carStateTimeout      = 100 * time.Millisecond
+	carStateStaleTimeout = 500 * time.Millisecond
+	modelV2Timeout       = 500 * time.Millisecond
 )
 
 func main() {
@@ -64,15 +65,14 @@ func main() {
 		now := time.Now()
 		carStatus := car.Status()
 		modelStatus := model.Status()
-		carHealthy := carStatus.Healthy(now, carStateTimeout)
+		state.CarValid = carStatus.Healthy(now, carStateStaleTimeout)
 		state.GpsValid = gps.Fresh(now)
 		state.ModelValid = modelStatus.Healthy(now, modelV2Timeout)
-		outputValid := carHealthy && state.GpsValid && state.MapValid && state.RouteValid
-		if ms.Settings.VisionCurveSpeedControlEnabled {
-			outputValid = outputValid && state.ModelValid
+		if !state.GpsValid && state.RouteValid {
+			state.ClearRoute()
 		}
 
-		err := state.Send(outputValid) // send beginning of each loop to ensure it happens at the correct rate
+		err := state.Send(state.CarValid) // send beginning of each loop to ensure it happens at the correct rate
 		if err != nil {
 			slog.Error("Failed to send update", "error", err)
 		}
@@ -121,29 +121,31 @@ func main() {
 
 		location, gpsSuccess := gps.Read()
 		if gpsSuccess {
-			state.RouteValid = false
 			state.DistanceSinceLastPosition = 0
 			state.Position = m.PosFromLocation(location)
 			pos := m.PosFromLocation(location)
 			box := state.Data.Box()
 			mapLoadTime := time.Now()
 			if !box.PosInside(pos) || (!state.Data.Loaded && mapLoadTime.Sub(lastMapLoadAttempt) >= mapLoadRetryDelay) {
-				state.MapValid = false
 				state.Data, err = maps.FindWaysAroundPosition(pos)
 				lastMapLoadAttempt = mapLoadTime
 				if err != nil {
 					slog.Debug("", "error", errors.Wrap(err, "Could not find ways around location"))
+					state.MapValid = false
+					state.ClearRoute()
 					continue
 				}
-				if !state.Data.Loaded {
-					continue
-				}
-				state.MapValid = true
+			}
+			state.MapValid = state.Data.Loaded
+			if !state.MapValid {
+				state.ClearRoute()
+				continue
 			}
 
 			state.CurrentWay, err = GetCurrentWay(state.CurrentWay, state.NextWays, &state.Data, location)
 			if err != nil {
 				slog.Debug("could not get current way", "error", err)
+				state.ClearRoute()
 				continue
 			}
 			state.RouteValid = true

--- a/main.go
+++ b/main.go
@@ -12,7 +12,11 @@ import (
 	ms "pfeifer.dev/mapd/settings"
 )
 
-const mapLoadRetryDelay = time.Second
+const (
+	mapLoadRetryDelay = time.Second
+	carStateTimeout   = 100 * time.Millisecond
+	modelV2Timeout    = 500 * time.Millisecond
+)
 
 func main() {
 	ms.Settings.Default()                // set defaults so settings not already in param are defaulted
@@ -57,7 +61,18 @@ func main() {
 	defer selfdriveState.Sub.Msgq.Close()
 
 	for {
-		err := state.Send() // send beginning of each loop to ensure it happens at the correct rate
+		now := time.Now()
+		carStatus := car.Status()
+		modelStatus := model.Status()
+		carHealthy := carStatus.Healthy(now, carStateTimeout)
+		state.GpsValid = gps.Fresh(now)
+		state.ModelValid = modelStatus.Healthy(now, modelV2Timeout)
+		outputValid := carHealthy && state.GpsValid && state.MapValid && state.RouteValid
+		if ms.Settings.VisionCurveSpeedControlEnabled {
+			outputValid = outputValid && state.ModelValid
+		}
+
+		err := state.Send(outputValid) // send beginning of each loop to ensure it happens at the correct rate
 		if err != nil {
 			slog.Error("Failed to send update", "error", err)
 		}
@@ -83,13 +98,19 @@ func main() {
 		}
 
 		carData, carStateSuccess := car.Read()
-		if carStateSuccess {
+		if carStateSuccess && car.Status().EventValid {
+			if !carStatus.Healthy(car.Status().ReceivedAt, carStateTimeout) {
+				state.Car.UpdateTime.Rebase()
+			}
 			state.UpdateCarState(carData)
 			UpdateCurveSpeed(&state)
 		}
 
 		modelData, modelSuccess := model.Read()
-		if modelSuccess {
+		if modelSuccess && model.Status().EventValid {
+			if !modelStatus.Healthy(model.Status().ReceivedAt, modelV2Timeout) {
+				state.VisionCurveMA.Reset()
+			}
 			state.VisionCurveSpeed = calcVisionCurveSpeed(modelData, &state)
 		}
 
@@ -100,35 +121,51 @@ func main() {
 
 		location, gpsSuccess := gps.Read()
 		if gpsSuccess {
+			state.RouteValid = false
 			state.DistanceSinceLastPosition = 0
 			state.Position = m.PosFromLocation(location)
 			pos := m.PosFromLocation(location)
 			box := state.Data.Box()
 			mapLoadTime := time.Now()
 			if !box.PosInside(pos) || (!state.Data.Loaded && mapLoadTime.Sub(lastMapLoadAttempt) >= mapLoadRetryDelay) {
+				state.MapValid = false
 				state.Data, err = maps.FindWaysAroundPosition(pos)
 				lastMapLoadAttempt = mapLoadTime
 				if err != nil {
 					slog.Debug("", "error", errors.Wrap(err, "Could not find ways around location"))
 					continue
 				}
+				if !state.Data.Loaded {
+					continue
+				}
+				state.MapValid = true
 			}
 
 			state.CurrentWay, err = GetCurrentWay(state.CurrentWay, state.NextWays, &state.Data, location)
 			if err != nil {
 				slog.Debug("could not get current way", "error", err)
+				continue
 			}
+			state.RouteValid = true
 
 			state.NextWays, err = NextWays(location, state.CurrentWay, &state.Data, state.CurrentWay.OnWay.IsForward)
 			if err != nil {
 				slog.Debug("could not get next way", "error", err)
+				state.NextWays = nil
+				state.SpeedLimit.NextLimit.Reset()
+				state.NextAdvisorySpeed.Reset()
+				state.NextHazard.Reset()
 			}
 
 			state.Curvatures, err = GetStateCurvatures(&state)
 			if err != nil {
 				slog.Debug("could not get curvatures from current state", "error", err)
+				state.Curvatures = nil
+				state.TargetVelocities = nil
+				state.MapCurveSpeed = 0
+			} else {
+				state.TargetVelocities = GetTargetVelocities(state.Curvatures, state.TargetVelocities)
 			}
-			state.TargetVelocities = GetTargetVelocities(state.Curvatures, state.TargetVelocities)
 		}
 
 		// send at beginning of next loop

--- a/state.go
+++ b/state.go
@@ -17,6 +17,7 @@ type State struct {
 	SpeedLimit                SpeedLimitState
 	NextWays                  []maps.NextWayResult
 	Position                  m.Position
+	CarValid                  bool
 	GpsValid                  bool
 	MapValid                  bool
 	ModelValid                bool
@@ -58,6 +59,22 @@ func (s *State) SuggestedSpeed() float32 {
 		suggestedSpeed = 0
 	}
 	return suggestedSpeed
+}
+
+func (s *State) RouteUsable() bool {
+	return s.GpsValid && s.MapValid && s.RouteValid
+}
+
+func (s *State) ClearRoute() {
+	s.RouteValid = false
+	s.CurrentWay = CurrentWay{}
+	s.NextWays = nil
+	s.Curvatures = nil
+	s.TargetVelocities = nil
+	s.MapCurveSpeed = 0
+	s.SpeedLimit.NextLimit.Reset()
+	s.NextAdvisorySpeed.Reset()
+	s.NextHazard.Reset()
 }
 
 func (s *State) UpdateCarState(carData car.CarState) {

--- a/state.go
+++ b/state.go
@@ -17,6 +17,10 @@ type State struct {
 	SpeedLimit                SpeedLimitState
 	NextWays                  []maps.NextWayResult
 	Position                  m.Position
+	GpsValid                  bool
+	MapValid                  bool
+	ModelValid                bool
+	RouteValid                bool
 	Curvatures                []m.Curvature
 	TargetVelocities          []Velocity
 	DistanceSinceLastPosition float32
@@ -44,7 +48,7 @@ func (s *State) SuggestedSpeed() float32 {
 			suggestedSpeed = slSuggestedSpeed
 		}
 	}
-	if ms.Settings.VisionCurveSpeedControlEnabled && s.VisionCurveSpeed > 0 && (s.VisionCurveSpeed < suggestedSpeed || suggestedSpeed == 0) && (!ms.Settings.VisionCurveUseEnableSpeed || s.Car.EnableSpeedActive) {
+	if s.ModelValid && ms.Settings.VisionCurveSpeedControlEnabled && s.VisionCurveSpeed > 0 && (s.VisionCurveSpeed < suggestedSpeed || suggestedSpeed == 0) && (!ms.Settings.VisionCurveUseEnableSpeed || s.Car.EnableSpeedActive) {
 		suggestedSpeed = s.VisionCurveSpeed
 	}
 	if ms.Settings.MapCurveSpeedControlEnabled && s.MapCurveSpeed > 0 && (s.MapCurveSpeed < suggestedSpeed || suggestedSpeed == 0) && (!ms.Settings.MapCurveUseEnableSpeed || s.Car.EnableSpeedActive) {
@@ -65,8 +69,12 @@ func (s *State) UpdateCarState(carData car.CarState) {
 	s.SpeedLimit.Update(s.CurrentWay, s.Car)
 }
 
-func (s *State) Send() error {
-	msg, output := s.Publisher.NewMessage(true)
+func (s *State) Send(valid bool) error {
+	msg, output := s.Publisher.NewMessage(valid)
+	if !valid {
+		return s.Publisher.Send(msg)
+	}
+
 	id := s.CurrentWay.Way.Id()
 	output.SetWayId(id)
 
@@ -111,7 +119,9 @@ func (s *State) Send() error {
 	output.SetRoadContext(custom.RoadContext(s.CurrentWay.Way.Context()))
 	output.SetHighwayClass(custom.HighwayClass(s.CurrentWay.Way.HighwayClass()))
 	output.SetEstimatedRoadWidth(s.CurrentWay.Way.Width())
-	output.SetVisionCurveSpeed(s.VisionCurveSpeed)
+	if s.ModelValid {
+		output.SetVisionCurveSpeed(s.VisionCurveSpeed)
+	}
 	output.SetMapCurveSpeed(s.MapCurveSpeed)
 
 	output.SetSuggestedSpeed(s.SuggestedSpeed())

--- a/utils/update_tracker.go
+++ b/utils/update_tracker.go
@@ -10,6 +10,7 @@ type UpdateTracker struct {
 	LastTime time.Time
 	Time     time.Time
 	DiffMA   m.MovingAverage
+	skipNext bool
 }
 
 func (u *UpdateTracker) Init(maLength int) {
@@ -18,8 +19,19 @@ func (u *UpdateTracker) Init(maLength int) {
 	u.DiffMA.Init(maLength)
 }
 
+func (u *UpdateTracker) Rebase() {
+	now := time.Now()
+	u.LastTime = now
+	u.Time = now
+	u.skipNext = true
+}
+
 func (u *UpdateTracker) Update() {
 	u.LastTime = u.Time
 	u.Time = time.Now()
+	if u.skipNext {
+		u.skipNext = false
+		return
+	}
 	u.DiffMA.Update(u.Time.Sub(u.LastTime).Seconds())
 }


### PR DESCRIPTION
## Summary

- Record semantic event validity and consumer-local receipt time for decoded subscriptions without changing the existing `Read()` API.
- Continuously poll both GPS providers, prefer a usable external fix, and fall back to a cached usable internal fix when external GPS becomes invalid or stale.
- Scope output validity to the inputs each feature actually depends on: `carState` health gates the envelope, GPS/map/route health gates only map-derived output, and vision-curve output survives both.

## Motivation

At Base [`68813e05`](https://github.com/pfeiferj/mapd/commit/68813e05b4db68764b7d9dbb73b7998726223c45), a subscriber reports success after structural decode and union selection. It does not inspect `Event.valid` or retain when the message was received, so invalid or indefinitely retained car, model, and GPS data is indistinguishable from live input.

GPS selection compounds that problem. The first decoded external packet permanently latches the external subscriber; the internal queue is no longer drained, so a later external stall cannot fall back to a healthy internal source. The main loop also republishes retained state as valid before reading new inputs, which allows stale limits, hazards, curves, and paths to remain externally valid.

These are one transition contract rather than independent fixes: a normal 20 Hz poll can legitimately see no new packet between 10 Hz external GPS updates, so failover needs the same persisted validity and receiver-observed freshness state used to determine output health.

## Health contract

| Input/state | Usable condition | Effect when unusable |
|---|---|---|
| `carState` | `Event.valid` and local receipt age < 500 ms | Publish invalid/default-zero `mapdOut`. Every published field derives from car state, so this is the one input that invalidates the whole envelope. On recovery, skip the unknown outage interval instead of feeding it into the car timing average (gap threshold stays 100 ms). |
| `modelV2` | `Event.valid` and local receipt age < 500 ms | Omit the stale vision value and exclude it from speed arbitration. Reset the vision moving average on recovery so the first fresh trajectory is not blended with pre-stall history. |
| External GPS | `Event.valid`, a reported fix, and local receipt age < 1 s | Prefer internal GPS if its cached sample remains usable. |
| Internal GPS | `Event.valid`, a reported fix, and local receipt age < 10 s | No selected position source; clear map-derived state. Vision-curve and external speed limit output continue. |
| Offline tile | Loaded and covering the selected position | Clear map-derived state and publish an empty extended path; `tileLoaded` continues to report the condition. |
| Current road | Successfully resolved from the selected position | Clear map-derived state and publish an empty extended path. |
| Lookahead/curvature | Optional derived state | Clear only the affected upcoming or curve state; keep valid current-road output. |
| `mapdIn` / `mapdCli` | Successfully decoded command | Preserve existing behavior regardless of `Event.valid`; these on-demand command envelopes do not expire. |

Freshness uses receiver-local time, not producer `logMonoTime` or GPS wall time. The boundary is strict: a sample is stale at exactly its timeout.

The `carState` window is 500 ms rather than a ten-period 100 ms, because the daemon's own loop can exceed 100 ms between reads when a tile-boundary crossing loads and parses a tile; a tighter window converts that routine work into spurious invalid frames. The 100 ms threshold is retained where it belongs, as the inter-message gap that rebases the car timing average.

GPS fix compatibility accepts `hasFix` or the legacy bit-zero fix flag. Cap'n Proto exposes no presence bit for `hasFix`, so an odd legacy flag remains authoritative when `hasFix` is false.

Source selection is debounced: external is adopted immediately when no healthy internal fix exists, but while internal is healthy external must stay healthy for 2 s before it takes over. Failover away from a stale external source is never delayed.

## Behavior

| Transition | Base | Head |
|---|---|---|
| Startup without healthy driving inputs | Publishes a valid envelope containing retained/default state | Publishes an invalid envelope with default-zero fields |
| Decoded invalid car/model/GPS event | Applies the payload | Records the receipt but does not apply it |
| Healthy external GPS between normal 10 Hz packets | External remains latched | External remains selected until its 1 s freshness window expires |
| External stalls while internal remains fresh | Stops receiving positions and never checks internal again | Fails over to internal and continues draining both providers |
| External recovers | Resumes only because it was permanently selected | Retakes priority after 2 s of continuous health |
| External degraded to roughly its timeout cadence | Latched; no switching | Debounce holds one source instead of switching per tick |
| Both GPS providers become unusable | Retains and republishes the last map state as valid | Clears map-derived state; vision-curve and external speed limit output continue |
| No tiles downloaded, or driving off-map | Publishes empty map fields with `tileLoaded` false | Unchanged, and vision-curve/external speed limit control keep working |
| Tile load or current-road resolution fails | Can retain and republish dependent route/control fields | Clears map-derived state until a later position produces loaded map data and a current road |
| Lookahead or curvature derivation fails | Can retain affected derived state | Clears the affected upcoming/curve state without discarding valid current-road data |
| Car input recovers after a gap | The outage interval can enter distance timing | Advances timestamps without inserting the unknown interval into the moving average |
| Model input recovers after a gap | Blends the fresh trajectory with retained pre-stall samples | Reinitializes vision smoothing from the fresh trajectory |
| Default-invalid `mapdIn` command | Handled | Unchanged; handled |

## Validation

- **Exact change:** Head [`669b5e07`](https://github.com/FrogAi/mapd/commit/669b5e079bbc852eb0951282cb59bb88ec5040f3) changes six production files and adds no test files.
- **Exact-head review:** Static state-transition oracles covered unseen, valid, invalid, future-dated, fresh, exact-timeout, and recovered subscriber states; external/internal GPS priority and fallback; command compatibility; car/model recovery; tile/current-road failures; short and dead-end roads; optional lookahead/curvature failures; and both output serializers.
- **Independent review:** An adversarial audit of the preceding head [`bedfde92`](https://github.com/FrogAi/mapd/commit/bedfde92e3e482a979df9ea4d871a7c344965b5a) drove the corrections in this head. It reproduced, with a fake-clock harness over real msgq queues, 18 GPS source switches in 10 s when external GPS degraded to roughly a 1 s cadence while internal stayed healthy, and established that an all-or-nothing output gate silenced vision-curve control and external speed limits whenever GPS, tiles, or current-road resolution were unavailable â€” including permanently on an install with no tiles downloaded. That audit separately verified the failover state machine itself against its specification: cold start, preference, strict timeout boundaries, recovery, invalid-event and no-fix rejection, and legacy flag acceptance.
- **Failover harness:** An audit-only fake-clock harness over the selection logic confirms the corrected head holds one source across 200 ticks of degraded external cadence (0 switches, against 18 on `bedfde92`), adopts external immediately when no internal fix exists, defers promotion while internal is healthy, fails over on external staleness, and reports both-dead as no source with `Fresh()` false.
- **Compile evidence:** [FrogAi Build #35](https://github.com/FrogAi/mapd/actions/runs/31288637039) completed `make build` successfully for exact Head `669b5e07`.
- **Evidence limit:** No hardware or on-road failover run was executed. The transition matrix above is exact-source reasoning supported by the fake-clock harness, not a runtime end-to-end test.

## Compatibility and scope

- No Cap'n Proto schema, published field definition, setting, CLI contract, or subscriber `Read()` signature changes.
- `Event.valid` on `mapdOut` now carries health semantics: it is false when car state is stale, and its payload is default-zero in that case. Consumers that ignore `Event.valid` see zeroed fields during a car-state outage.
- Map-derived fields (road identity, speed limits, hazards, advisory speeds, map curve speed, extended path) return to their default values while GPS, tiles, or current-road resolution are unavailable, rather than retaining their last values. `tileLoaded` continues to signal the missing-map case.
- Vision-curve speed and externally supplied speed limits are unaffected by GPS, tile, or current-road availability.
- Command channels retain decoded-message semantics, including current `Event.valid=false` download/cancel inputs.
- External GPS remains preferred, and internal GPS is now kept current for fallback.
- `mapdExtendedOut` remains valid for independent settings and download progress; only its GPS/map/current-road path is emptied when unavailable.
- No producer-timestamp ordering, coordinate plausibility/accuracy policy, tile retry/backoff, schema-level per-field validity, or downstream-consumer change is included.


## Merge order with #114

[#114](https://github.com/pfeiferj/mapd/pull/114) rate-limits tile-load retries in the same loop this PR restructures. The two conflict in `main.go`, but **only** in the both-added declaration block near the top, where the union is the only resolution that compiles. The semantically important hunk auto-merges silently about 115 lines below, inside the GPS branch, where a maintainer reviewing the conflict would never look â€” the same class of hazard that made the #112/#113 merge silently corrupt tiles.

A trial merge confirms #114's retry bookkeeping lands *above* this PR's early exits, so the backoff is not defeated. What remains is two stacked "map unusable" exits with different bookkeeping: this PR's `if !state.MapValid { ClearRoute(); continue }` and #114's bare tile-loaded gate, which sets neither `MapValid` nor clears the route. No currently reachable stale-state leak was constructed, so it is redundant rather than broken â€” but because `MapValid` would then be assigned only inside the backoff branch, any future widening of the retry delay makes the bare gate the live exit and silently skips this PR's invalidation.

Land this PR first, then fold #114's gate into the single form `state.MapValid = state.Data.Loaded; if !state.MapValid { state.ClearRoute(); continue }` rather than leaving both. Composition with [#118](https://github.com/pfeiferj/mapd/pull/118) and [#119](https://github.com/pfeiferj/mapd/pull/119) is clean and needs no intervention; the four-PR stack is byte-identical to the union of the pairs.

## Rebased onto current `main` (`8dcfd0a`)

Two things landed in `main` underneath this PR: shadow-subscription settings, which changed how the GPS subscribers are constructed, and [#114](https://github.com/pfeiferj/mapd/pull/114)'s tile-retry rate limiting, which rewrote the same map-load block this PR restructures. The rebase keeps `main`'s `SubscriberSettings.ShadowGpsLocation` / `ShadowGpsLocationExternal` wiring alongside this PR's failover state machine, and unions the two declaration blocks.

The map-load composition was resolved deliberately rather than mechanically. #114's retry gate is preserved, and `state.MapValid = state.Data.Loaded` is now assigned on **every** GPS tick rather than only inside the retry branch, with an unloaded tile clearing route state before continuing. Leaving both gates in place would have worked today but made `MapValid` sticky: it would only be reassigned when the backoff allowed a load attempt, so any future widening of the retry delay would silently skip this PR's invalidation. The collapsed form also means a corrupt tile clears the current way rather than freezing the previous cell's speed limit — the regression #114 was itself corrected for.

Re-verified against the rebased base: the failover harness still shows no source flapping across 200 ticks of degraded external cadence, immediate adoption of external when no internal fix exists, deferred promotion while internal is healthy, failover on external staleness, and both-dead reported as no source with `Fresh()` false. [FrogAi Build #59](https://github.com/FrogAi/mapd/actions/runs/31321569421) passed for the exact head.
