### PR TITLE
Install map archives transactionally

### DIFF
--- a/settings/download.go
+++ b/settings/download.go
@@ -147,41 +147,15 @@ func Download(paths string, progressChan chan DownloadProgress, cancelChan chan 
 	}
 }
 
-type archiveFile interface {
-	io.Writer
-	Sync() error
-	Close() error
-}
-
-type archiveInstallOps struct {
-	mkdirTemp func(string, string) (string, error)
-	mkdirAll  func(string, os.FileMode) error
-	openFile  func(string, int, os.FileMode) (archiveFile, error)
-	rename    func(string, string) error
-	removeAll func(string) error
-	stat      func(string) (os.FileInfo, error)
-}
-
-var defaultArchiveInstallOps = archiveInstallOps{
-	mkdirTemp: os.MkdirTemp,
-	mkdirAll:  os.MkdirAll,
-	openFile: func(name string, flag int, perm os.FileMode) (archiveFile, error) {
-		return os.OpenFile(name, flag, perm)
-	},
-	rename:    os.Rename,
-	removeAll: os.RemoveAll,
-	stat:      os.Stat,
-}
-
 func cleanArchivePath(name string) (string, error) {
 	clean := filepath.Clean(name)
-	if name == "" || clean == "." || filepath.IsAbs(clean) || clean == ".." || strings.HasPrefix(clean, ".."+string(os.PathSeparator)) {
+	if clean == "." || filepath.IsAbs(clean) || clean == ".." || strings.HasPrefix(clean, ".."+string(os.PathSeparator)) {
 		return "", errors.Errorf("invalid archive path: %q", name)
 	}
 	return clean, nil
 }
 
-func writeArchiveFile(file archiveFile, reader io.Reader, expectedSize int64) error {
+func writeArchiveFile(file *os.File, reader io.Reader, expectedSize int64) error {
 	written, err := io.Copy(file, reader)
 	if err != nil {
 		file.Close()
@@ -201,7 +175,7 @@ func writeArchiveFile(file archiveFile, reader io.Reader, expectedSize int64) er
 	return nil
 }
 
-func extractArchiveToStage(archivePath string, stageRoot string, expectedRoot string, ops archiveInstallOps) error {
+func extractArchiveToStage(archivePath string, stageRoot string, expectedRoot string) error {
 	file, err := os.Open(archivePath)
 	if err != nil {
 		return errors.Wrap(err, "could not open downloaded file")
@@ -250,21 +224,21 @@ func extractArchiveToStage(archivePath string, stageRoot string, expectedRoot st
 
 		// if its a dir and it doesn't exist create it
 		case tar.TypeDir:
-			if _, err := ops.stat(target); err != nil {
+			if _, err := os.Stat(target); err != nil {
 				if !os.IsNotExist(err) {
 					return errors.Wrap(err, "could not inspect staged archive directory")
 				}
-				if err := ops.mkdirAll(target, os.FileMode(header.Mode).Perm()); err != nil {
+				if err := os.MkdirAll(target, 0o755); err != nil {
 					return errors.Wrap(err, "could not create staged archive directory")
 				}
 			}
 
 		// if it's a file create it
-		case tar.TypeReg, tar.TypeRegA:
-			if err := ops.mkdirAll(filepath.Dir(target), 0o755); err != nil {
+		case tar.TypeReg:
+			if err := os.MkdirAll(filepath.Dir(target), 0o755); err != nil {
 				return errors.Wrap(err, "could not create staged archive parent directory")
 			}
-			stagedFile, err := ops.openFile(target, os.O_CREATE|os.O_EXCL|os.O_WRONLY, os.FileMode(header.Mode).Perm())
+			stagedFile, err := os.OpenFile(target, os.O_CREATE|os.O_EXCL|os.O_WRONLY, os.FileMode(header.Mode).Perm())
 			if err != nil {
 				return errors.Wrap(err, "could not open staged archive file")
 			}
@@ -286,9 +260,9 @@ func extractArchiveToStage(archivePath string, stageRoot string, expectedRoot st
 	return nil
 }
 
-func commitArchiveGroup(stageRoot string, basePath string, expectedRoot string, ops archiveInstallOps) (bool, error) {
+func commitArchiveGroup(stageRoot string, basePath string, expectedRoot string) (bool, error) {
 	stagedGroup := filepath.Join(stageRoot, expectedRoot)
-	stagedInfo, err := ops.stat(stagedGroup)
+	stagedInfo, err := os.Stat(stagedGroup)
 	if err != nil {
 		return false, errors.Wrap(err, "could not inspect staged archive group")
 	}
@@ -297,14 +271,14 @@ func commitArchiveGroup(stageRoot string, basePath string, expectedRoot string, 
 	}
 
 	liveGroup := filepath.Join(basePath, expectedRoot)
-	if err := ops.mkdirAll(filepath.Dir(liveGroup), 0o755); err != nil {
+	if err := os.MkdirAll(filepath.Dir(liveGroup), 0o755); err != nil {
 		return false, errors.Wrap(err, "could not create live archive parent directory")
 	}
 
 	backupGroup := filepath.Join(stageRoot, "backup")
 	hadLiveGroup := false
-	if _, err := ops.stat(liveGroup); err == nil {
-		if err := ops.rename(liveGroup, backupGroup); err != nil {
+	if _, err := os.Stat(liveGroup); err == nil {
+		if err := os.Rename(liveGroup, backupGroup); err != nil {
 			return false, errors.Wrap(err, "could not move live archive group to backup")
 		}
 		hadLiveGroup = true
@@ -312,9 +286,9 @@ func commitArchiveGroup(stageRoot string, basePath string, expectedRoot string, 
 		return false, errors.Wrap(err, "could not inspect live archive group")
 	}
 
-	if err := ops.rename(stagedGroup, liveGroup); err != nil {
+	if err := os.Rename(stagedGroup, liveGroup); err != nil {
 		if hadLiveGroup {
-			if restoreErr := ops.rename(backupGroup, liveGroup); restoreErr != nil {
+			if restoreErr := os.Rename(backupGroup, liveGroup); restoreErr != nil {
 				return true, errors.Wrapf(err, "could not install staged archive group and could not restore backup at %q: %v", backupGroup, restoreErr)
 			}
 		}
@@ -323,7 +297,20 @@ func commitArchiveGroup(stageRoot string, basePath string, expectedRoot string, 
 	return false, nil
 }
 
-func installArchiveWithOps(archivePath string, basePath string, expectedRoot string, ops archiveInstallOps) error {
+func removeOrphanedStagingDirs(basePath string) {
+	matches, err := filepath.Glob(filepath.Join(basePath, ".mapd-install-*"))
+	if err != nil {
+		slog.Warn("could not scan for orphaned archive staging directories", "error", err)
+		return
+	}
+	for _, match := range matches {
+		if err := os.RemoveAll(match); err != nil {
+			slog.Warn("could not remove orphaned archive staging directory", "error", err, "directory", match)
+		}
+	}
+}
+
+func installArchive(archivePath string, basePath string, expectedRoot string) error {
 	cleanExpectedRoot, err := cleanArchivePath(expectedRoot)
 	if err != nil {
 		return err
@@ -332,7 +319,7 @@ func installArchiveWithOps(archivePath string, basePath string, expectedRoot str
 		return errors.Errorf("archive root is not canonical: %q", expectedRoot)
 	}
 
-	stageRoot, err := ops.mkdirTemp(basePath, ".mapd-install-")
+	stageRoot, err := os.MkdirTemp(basePath, ".mapd-install-")
 	if err != nil {
 		return errors.Wrap(err, "could not create archive staging directory")
 	}
@@ -341,20 +328,16 @@ func installArchiveWithOps(archivePath string, basePath string, expectedRoot str
 		if preserveStage {
 			return
 		}
-		if err := ops.removeAll(stageRoot); err != nil {
+		if err := os.RemoveAll(stageRoot); err != nil {
 			slog.Warn("could not remove archive staging directory", "error", err, "directory", stageRoot)
 		}
 	}()
 
-	if err := extractArchiveToStage(archivePath, stageRoot, expectedRoot, ops); err != nil {
+	if err := extractArchiveToStage(archivePath, stageRoot, expectedRoot); err != nil {
 		return err
 	}
-	preserveStage, err = commitArchiveGroup(stageRoot, basePath, expectedRoot, ops)
+	preserveStage, err = commitArchiveGroup(stageRoot, basePath, expectedRoot)
 	return err
-}
-
-func installArchive(archivePath string, basePath string, expectedRoot string) error {
-	return installArchiveWithOps(archivePath, basePath, expectedRoot, defaultArchiveInstallOps)
 }
 
 func adjustedBounds(bounds Bounds) (int, int, int, int) {
@@ -374,6 +357,8 @@ func adjustedBounds(bounds Bounds) (int, int, int, int) {
 
 func (d *download) downloadBounds(bounds Bounds, locationName string) (err error, cancel bool) {
 	slog.Info("Downloading Bounds", "min_lat", bounds.MinLat, "min_lon", bounds.MinLon, "max_lat", bounds.MaxLat, "max_lon", bounds.MaxLon)
+
+	removeOrphanedStagingDirs(params.GetBaseOpPath())
 
 	// clip given bounds to file areas
 	minLat, minLon, maxLat, maxLon := adjustedBounds(bounds)

--- a/settings/download.go
+++ b/settings/download.go
@@ -147,6 +147,216 @@ func Download(paths string, progressChan chan DownloadProgress, cancelChan chan 
 	}
 }
 
+type archiveFile interface {
+	io.Writer
+	Sync() error
+	Close() error
+}
+
+type archiveInstallOps struct {
+	mkdirTemp func(string, string) (string, error)
+	mkdirAll  func(string, os.FileMode) error
+	openFile  func(string, int, os.FileMode) (archiveFile, error)
+	rename    func(string, string) error
+	removeAll func(string) error
+	stat      func(string) (os.FileInfo, error)
+}
+
+var defaultArchiveInstallOps = archiveInstallOps{
+	mkdirTemp: os.MkdirTemp,
+	mkdirAll:  os.MkdirAll,
+	openFile: func(name string, flag int, perm os.FileMode) (archiveFile, error) {
+		return os.OpenFile(name, flag, perm)
+	},
+	rename:    os.Rename,
+	removeAll: os.RemoveAll,
+	stat:      os.Stat,
+}
+
+func cleanArchivePath(name string) (string, error) {
+	clean := filepath.Clean(name)
+	if name == "" || clean == "." || filepath.IsAbs(clean) || clean == ".." || strings.HasPrefix(clean, ".."+string(os.PathSeparator)) {
+		return "", errors.Errorf("invalid archive path: %q", name)
+	}
+	return clean, nil
+}
+
+func writeArchiveFile(file archiveFile, reader io.Reader, expectedSize int64) error {
+	written, err := io.Copy(file, reader)
+	if err != nil {
+		file.Close()
+		return errors.Wrap(err, "could not write staged archive file")
+	}
+	if written != expectedSize {
+		file.Close()
+		return errors.Errorf("staged archive file size mismatch: wrote %d bytes, expected %d", written, expectedSize)
+	}
+	if err := file.Sync(); err != nil {
+		file.Close()
+		return errors.Wrap(err, "could not fsync staged archive file")
+	}
+	if err := file.Close(); err != nil {
+		return errors.Wrap(err, "could not close staged archive file")
+	}
+	return nil
+}
+
+func extractArchiveToStage(archivePath string, stageRoot string, expectedRoot string, ops archiveInstallOps) error {
+	file, err := os.Open(archivePath)
+	if err != nil {
+		return errors.Wrap(err, "could not open downloaded file")
+	}
+	defer file.Close()
+
+	reader, err := gzip.NewReader(file)
+	if err != nil {
+		return errors.Wrap(err, "could not parse gzip downloaded file")
+	}
+	defer reader.Close()
+
+	tr := tar.NewReader(reader)
+	seen := make(map[string]struct{})
+	regularFiles := 0
+	for {
+		header, err := tr.Next()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			return errors.Wrap(err, "could not read downloaded tar archive")
+		}
+
+		// if the header is nil, just skip it (not sure how this happens)
+		if header == nil {
+			continue
+		}
+
+		name, err := cleanArchivePath(header.Name)
+		if err != nil {
+			return err
+		}
+		if name != expectedRoot && !strings.HasPrefix(name, expectedRoot+string(os.PathSeparator)) {
+			return errors.Errorf("archive entry %q is outside expected root %q", header.Name, expectedRoot)
+		}
+		if _, exists := seen[name]; exists {
+			return errors.Errorf("duplicate archive entry: %q", header.Name)
+		}
+		seen[name] = struct{}{}
+
+		// the target location where the dir/file should be created
+		target := filepath.Join(stageRoot, name)
+		// check the file type
+		switch header.Typeflag {
+
+		// if its a dir and it doesn't exist create it
+		case tar.TypeDir:
+			if _, err := ops.stat(target); err != nil {
+				if !os.IsNotExist(err) {
+					return errors.Wrap(err, "could not inspect staged archive directory")
+				}
+				if err := ops.mkdirAll(target, os.FileMode(header.Mode).Perm()); err != nil {
+					return errors.Wrap(err, "could not create staged archive directory")
+				}
+			}
+
+		// if it's a file create it
+		case tar.TypeReg, tar.TypeRegA:
+			if err := ops.mkdirAll(filepath.Dir(target), 0o755); err != nil {
+				return errors.Wrap(err, "could not create staged archive parent directory")
+			}
+			stagedFile, err := ops.openFile(target, os.O_CREATE|os.O_EXCL|os.O_WRONLY, os.FileMode(header.Mode).Perm())
+			if err != nil {
+				return errors.Wrap(err, "could not open staged archive file")
+			}
+			if err := writeArchiveFile(stagedFile, tr, header.Size); err != nil {
+				return err
+			}
+			regularFiles++
+		default:
+			return errors.Errorf("unsupported archive entry type %d for %q", header.Typeflag, header.Name)
+		}
+	}
+
+	if _, err := io.Copy(io.Discard, reader); err != nil {
+		return errors.Wrap(err, "could not validate gzip trailer")
+	}
+	if regularFiles == 0 {
+		return errors.New("downloaded archive contains no regular files")
+	}
+	return nil
+}
+
+func commitArchiveGroup(stageRoot string, basePath string, expectedRoot string, ops archiveInstallOps) (bool, error) {
+	stagedGroup := filepath.Join(stageRoot, expectedRoot)
+	stagedInfo, err := ops.stat(stagedGroup)
+	if err != nil {
+		return false, errors.Wrap(err, "could not inspect staged archive group")
+	}
+	if !stagedInfo.IsDir() {
+		return false, errors.Errorf("staged archive root is not a directory: %q", expectedRoot)
+	}
+
+	liveGroup := filepath.Join(basePath, expectedRoot)
+	if err := ops.mkdirAll(filepath.Dir(liveGroup), 0o755); err != nil {
+		return false, errors.Wrap(err, "could not create live archive parent directory")
+	}
+
+	backupGroup := filepath.Join(stageRoot, "backup")
+	hadLiveGroup := false
+	if _, err := ops.stat(liveGroup); err == nil {
+		if err := ops.rename(liveGroup, backupGroup); err != nil {
+			return false, errors.Wrap(err, "could not move live archive group to backup")
+		}
+		hadLiveGroup = true
+	} else if !os.IsNotExist(err) {
+		return false, errors.Wrap(err, "could not inspect live archive group")
+	}
+
+	if err := ops.rename(stagedGroup, liveGroup); err != nil {
+		if hadLiveGroup {
+			if restoreErr := ops.rename(backupGroup, liveGroup); restoreErr != nil {
+				return true, errors.Wrapf(err, "could not install staged archive group and could not restore backup at %q: %v", backupGroup, restoreErr)
+			}
+		}
+		return false, errors.Wrap(err, "could not install staged archive group")
+	}
+	return false, nil
+}
+
+func installArchiveWithOps(archivePath string, basePath string, expectedRoot string, ops archiveInstallOps) error {
+	cleanExpectedRoot, err := cleanArchivePath(expectedRoot)
+	if err != nil {
+		return err
+	}
+	if cleanExpectedRoot != expectedRoot {
+		return errors.Errorf("archive root is not canonical: %q", expectedRoot)
+	}
+
+	stageRoot, err := ops.mkdirTemp(basePath, ".mapd-install-")
+	if err != nil {
+		return errors.Wrap(err, "could not create archive staging directory")
+	}
+	preserveStage := false
+	defer func() {
+		if preserveStage {
+			return
+		}
+		if err := ops.removeAll(stageRoot); err != nil {
+			slog.Warn("could not remove archive staging directory", "error", err, "directory", stageRoot)
+		}
+	}()
+
+	if err := extractArchiveToStage(archivePath, stageRoot, expectedRoot, ops); err != nil {
+		return err
+	}
+	preserveStage, err = commitArchiveGroup(stageRoot, basePath, expectedRoot, ops)
+	return err
+}
+
+func installArchive(archivePath string, basePath string, expectedRoot string) error {
+	return installArchiveWithOps(archivePath, basePath, expectedRoot, defaultArchiveInstallOps)
+}
+
 func adjustedBounds(bounds Bounds) (int, int, int, int) {
 	minLat := int(math.Floor(bounds.MinLat/float64(GROUP_AREA_BOX_DEGREES))) * GROUP_AREA_BOX_DEGREES
 	minLon := int(math.Floor(bounds.MinLon/float64(GROUP_AREA_BOX_DEGREES))) * GROUP_AREA_BOX_DEGREES
@@ -194,70 +404,15 @@ func (d *download) downloadBounds(bounds Bounds, locationName string) (err error
 				slog.Warn("failed to download file, continuing to next", "error", err, "url", url, "file", outputName)
 				continue
 			}
-			file, err := os.Open(outputName)
-			if err != nil {
-				slog.Warn("failed to open downloaded file", "error", err, "file", outputName)
+			installErr := installArchive(outputName, params.GetBaseOpPath(), strings.TrimSuffix(filename, ".tar.gz"))
+			if installErr != nil {
+				slog.Warn("failed to install downloaded archive", "error", installErr, "file", outputName)
 			}
-			reader, err := gzip.NewReader(file)
-			if err != nil {
-				slog.Warn("failed to parse gzip downloaded file", "error", err, "file", outputName)
-			}
-			tr := tar.NewReader(reader)
-			for {
-				header, err := tr.Next()
-				if err != nil {
-					break
-				}
-
-				// if the header is nil, just skip it (not sure how this happens)
-				if header == nil {
-					continue
-				}
-				// the target location where the dir/file should be created
-				target := filepath.Join(params.GetBaseOpPath(), header.Name)
-				// check the file type
-				switch header.Typeflag {
-
-				// if its a dir and it doesn't exist create it
-				case tar.TypeDir:
-					if _, err := os.Stat(target); err != nil {
-						err := os.MkdirAll(target, 0o755)
-						if err != nil {
-							slog.Warn("could not create directory from downloaded gzip", "error", err, "file", outputName, "directory", target)
-						}
-					}
-
-				// if it's a file create it
-				case tar.TypeReg:
-					f, err := os.OpenFile(target, os.O_CREATE|os.O_RDWR, os.FileMode(header.Mode))
-					if err != nil {
-						slog.Warn("could not open file target from downloaded gzip", "error", err, "file", outputName, "targetFile", target)
-					}
-
-					_, err = io.Copy(f, tr)
-					if err != nil {
-						slog.Warn("could not write data to file target from downloaded gzip", "error", err, "file", outputName, "targetFile", target)
-					}
-
-					err = f.Sync()
-					if err != nil {
-						slog.Warn("could not fsync file target from downloaded gzip", "error", err, "file", outputName, "targetFile", target)
-					}
-					f.Close()
-				}
-			}
-			err = reader.Close()
-			if err != nil {
-				slog.Warn("could not close gzip reader", "error", err)
-			}
-			err = file.Close()
-			if err != nil {
-				slog.Warn("could not close downloaded file", "error", err)
-			}
-
-			err = os.Remove(outputName)
-			if err != nil {
+			if err := os.Remove(outputName); err != nil {
 				slog.Warn("could not delete downloaded gzip file", "error", err)
+			}
+			if installErr != nil {
+				continue
 			}
 
 			d.progress.DownloadedFiles++


### PR DESCRIPTION
## Summary

- Stage and validate each complete offline map group before touching the live files.
- Require clean in-group paths, supported entry types, unique entries, complete file writes, and clean tar/gzip completion.
- Replace the live group through backup and rollback renames, and advance progress only after the replacement commits.

## Motivation

The existing extractor writes archive members directly into the live map directory. A malformed header, truncated body, gzip checksum failure, file write failure, or process error can therefore leave a mixture of old and partially extracted files. Those failures are logged, but the archive can still be removed and counted as downloaded.

The current file open mode also does not truncate existing files, so replacing a tile with a shorter payload can retain bytes from the old file. Because each downloaded archive contains one complete `offline/<latitude>/<longitude>` group, installing it as one validated group is the correct ownership boundary.

## Behavior

| Scenario | Base | Head |
|---|---|---|
| Invalid gzip or malformed/truncated tar | May panic or leave partial live files; progress can still advance | Rejects the archive before commit; live group and progress remain unchanged |
| Corrupt gzip trailer | Extracted content can be accepted | Drains and validates gzip completion before commit |
| Shorter replacement file | Old trailing bytes can remain | Writes a new staged file into a fresh staging tree, so no stale bytes can survive |
| Wrong root, traversal, duplicate path, or unsupported entry type | Can escape the expected group or be ignored inconsistently | Rejects the entire archive |
| Write, sync, or close failure | Can leave live files modified | Aborts the staged installation without changing live files |
| Live-group backup rename fails | No transactional boundary | Leaves the existing live group untouched |
| Staged-group install rename fails | No rollback | Restores the previous group; if restoration also fails, preserves the backup and reports its path |
| Successful archive | Overlays files and can retain obsolete files | Replaces the complete group and increments progress once |

## Validation

- **Audit evidence:** source tracing on `68813e05` confirmed direct live writes, non-truncating file opens, undifferentiated tar termination, and progress updates after extraction errors.
- **Exact-head review:** two independent reviews traced the failure paths and accepted `c92bda11db7ba1936d58611182b5ecf0ec3efdba` with no material blockers. The reviewed matrix covers invalid gzip, malformed/truncated tar, corrupt trailers, path/type/duplicate rejection, write/sync/close failures, both rename failures, rollback failure preservation, exact shorter replacement, and successful replacement.
- **Build:** [FrogAi Build #52](https://github.com/FrogAi/mapd/actions/runs/31319168074) completed `make build` successfully for exact head [`c64d04e`](https://github.com/FrogAi/mapd/commit/c64d04eb769fbce8fd167390ff94657d9064adff). The workflow establishes compilation; the failure matrix is static source-path validation rather than executed fault injection or a tile replay.
- **Adversarial audit and follow-up commit.** An independent multi-agent audit of `c92bda1` installed twelve real production archives (1.7 KB to 55 MB, four continents) and confirmed byte-identical output trees against a verbatim baseline port, reproduced all four fixed baseline defects, and confirmed the CI claim. It raised three items, all addressed in `c64d04e`:
  - **Orphaned staging directories are now reclaimed.** Cleanup lived only in a `defer`, and the repo installs no signal handlers, so any kill or power loss stranded a `.mapd-install-*` tree (~40 MB each) that nothing ever swept — the existing sweep only covers `<base>/tmp`. `downloadBounds` now removes stale `.mapd-install-*` directories before starting. Verified: three interrupted installs left three orphans that survived both the `tmp` sweep and a later successful install on the previous head, and are reclaimed now.
  - **The `archiveInstallOps` injection seam is removed** (~30 of the original lines). It had a single caller always passing the default, no tests, and could not reach the failure paths it existed for — `os.Open` and `gzip.NewReader` bypassed it entirely. Call sites now use the `os` functions directly.
  - **Directory permissions no longer come from the archive.** `os.FileMode(header.Mode).Perm()` is replaced with a fixed `0o755`, matching base. Verified: an archive whose group entry carries mode `0555` installed a read-only `offline/38` on the previous head and installs `0755` now. The mode is umask-masked regardless, so honoring the archive had no upside.
  - Also dropped: the dead `tar.TypeRegA` case (Go normalizes it before `Next()` returns) and a `name == ""` check already covered by `clean == "."`.

## Compatibility and scope

- Merge order with [#107](https://github.com/pfeiferj/mapd/pull/107): the two conflict in `settings/download.go`, because #107 inserts a cancellation check against the block this PR replaces. The verified resolution keeps both, with the cancel check *first* and `installArchive` after it, leaving the `os.Remove` and `continue` intact — that ordering matters so a cancel still discards an already-downloaded archive as #107 does on base. The resolved merge, and #108+#107+#109 together, build and test clean. [#109](https://github.com/pfeiferj/mapd/pull/109) and [#110](https://github.com/pfeiferj/mapd/pull/110) merge without conflict.
- After merging with #107, note that this PR's `continue` on install failure skips #107's bottom-of-loop progress publish, so the progress bar stalls through a run of failing archives. Worth a follow-up, not addressed here.
- Download URLs, inputs, output schemas, progress totals, and the offline Cap'n Proto format are unchanged.
- A successful archive now authoritatively replaces its complete group, so obsolete files in that group are removed.
- The transaction boundary is one archive/group, not an entire multi-region download.
- Backup and install use two renames, which creates a brief interval where the live group path is absent. The change handles ordinary runtime failures but does not claim crash or power-loss durability.
- Archive size limits, authenticity, transport retries, and semantic validation of the extracted Cap'n Proto roots remain outside this change.
