### PR TITLE
Reject invalid offline roots

### DIFF
--- a/maps/offline.go
+++ b/maps/offline.go
@@ -20,9 +20,14 @@ func ReadOffline(data []uint8) Offline {
 		offlineMaps, err := offline.ReadRootOffline(msg)
 		if err != nil {
 			slog.Warn("could not read offline message", "error", err)
+			return Offline{Loaded: false}
+		}
+		if !offlineMaps.IsValid() {
+			slog.Warn("could not read offline message", "reason", "root is not a struct")
+			return Offline{Loaded: false}
 		}
 		// allow us to read as much as we want
-		offlineMaps.Message().ResetReadLimit(math.MaxUint64)
+		msg.ResetReadLimit(math.MaxUint64)
 		return Offline{offline: offlineMaps, Loaded: true}
 	}
 	return Offline{Loaded: false}


### PR DESCRIPTION
## Summary

- Return an unloaded tile when the packed message has no readable root.
- Reject null and non-struct roots before resetting the decoded message's read limit.
- Preserve the existing read-limit policy and valid empty/populated tile behavior.

## Motivation

`ReadOffline` already treated packed-message decode failures as unloaded tiles, but it did not stop after an Offline-root failure. A message with no root logs the error and then calls `ResetReadLimit` through an invalid root whose message is nil. A null or list root is a second path to the same crash: Cap'n Proto can return no root-read error while the generated `Offline` view is still invalid.

The caller already owns the unloaded-tile fallback, so the complete fix belongs in `ReadOffline`: reject a root-read error or invalid struct view before resetting the message read limit.

## Behavior

| Payload | Base `68813e05` | Head `e043b24` |
|---|---|---|
| Packed message without a root | Panics after logging the root error | Returns `Loaded=false` |
| Null root pointer | Panics while resetting the read limit | Returns `Loaded=false` |
| Text/list root | Panics while resetting the read limit | Returns `Loaded=false` |
| Truncated packed Offline | Returns `Loaded=false` | Unchanged |
| Valid empty Offline | Loads with zero ways | Unchanged |
| Valid populated Offline | Loads the original bounds and way data | Unchanged |

## Validation

- An external Linux overlay reproduced the no-root, null-root, and list-root panics on base `68813e05`. On exact head `e043b24649fa84170ab702203f372d5e10b0f8ba`, the complete six-case matrix passed: all three invalid roots returned unloaded, the truncated payload remained unloaded, and valid empty/populated tiles retained their original results.
- The same Go 1.25.1 linux/amd64 environment passed `go test ./...`, `go vet ./...`, and `go build ./...` against the exact head.
- Static dependency review covered malformed root-pointer errors, null and non-struct conversion, valid empty roots, schema-evolution-compatible struct sizes, nested-field behavior, and the downstream unloaded-tile policy.
- [FrogAi Build #39](https://github.com/FrogAi/mapd/actions/runs/31300140790) completed the branch `make build` path successfully for the exact head commit.

## Compatibility and scope

- No API, schema, generated binding, file-format, settings, or dependency changes.
- Valid empty Offline roots remain loaded; zero-way tiles are not reclassified as malformed.
- The unlimited nested-read policy is unchanged and is applied after the root has been read successfully and confirmed as a valid struct view.
- Cap'n Proto does not carry schema identity for a struct root here. The fix rejects missing, null, and non-struct roots, but it does not claim that every readable struct was authored as `Offline` or eagerly validate nested way data.
- No archive-installation, tile-retry, or route-state code changes are included.
