### PR TITLE
Stop map publication on PBF scan errors

### DIFF
--- a/maps/generate_offline.go
+++ b/maps/generate_offline.go
@@ -198,6 +198,10 @@ func GenerateOffline(s OfflineSettings) {
 			scannedWays = append(scannedWays, tmpWay)
 		}
 	}
+	if err := scanner.Err(); err != nil {
+		slog.Error("could not scan map pbf file", "error", err)
+		panic("failed to scan maps, exiting")
+	}
 
 	slog.Info("Finding Bounds")
 	for _, area := range areas {

--- a/scripts/generate_and_update_planet.sh
+++ b/scripts/generate_and_update_planet.sh
@@ -15,7 +15,7 @@ do
     echo "$i $j $max_lon $max_lat"
     ./extract_box.sh $i $j $max_lon $max_lat
     ./add_locations.sh
-    ./mapd generate --minlat $j --minlon $i --maxlat $max_lat --maxlon $max_lon
+    ./mapd generate --minlat $j --minlon $i --maxlat $max_lat --maxlon $max_lon || exit 1
     ./compress_offline.sh
     ./upload_offline.sh
     #./upload_small_offline.sh


### PR DESCRIPTION
## Summary

- Check the PBF scanner result before constructing or writing any offline tile.
- Stop the generation pipeline before compression and upload when `mapd generate` fails.
- Preserve clean-EOF handling and valid PBF generation behavior.

## Motivation

The pinned `osmpbf.Scanner` returns `false` from `Scan()` for both clean EOF and scanner failures. Callers must inspect `Err()` afterward to distinguish them. `GenerateOffline` did not perform that check, so a truncated PBF was treated as complete: the decoded prefix was written as valid offline tiles, generation logged completion, and the CLI exited successfully.

The production generation script also ignored the CLI result and continued into compression and upload. A generator-side check alone would stop new tile writes, but it would not stop the publication workflow.

All PBF scanning already completes before the first bounds directory or tile file is created. The complete fix is therefore an immediate post-scan error check, followed by a targeted script guard. On failure, the generator logs the scanner error and uses its existing fatal-error convention; the script then exits before downstream artifact processing.

## Behavior

| Case | Base `68813e05` | Head `76502e6` |
|---|---|---|
| 5,000,000-byte truncated PBF, after 723,870 nodes and 4,130 ways | CLI exits 0, writes 18 prefix-derived tiles, and logs completion | CLI exits nonzero, writes no tile files, reports the scanner error, and omits completion |
| Same failure with one pre-existing sentinel file | Output tree expands to 19 files | Existing one-file tree remains unchanged |
| Complete 7,812,234-byte PBF | Generation succeeds | Unchanged |
| Publication script with a failing generator | Runs all 162 generator iterations and invokes compression/upload 162 times | Stops after one generator attempt; compression and upload are not invoked |

## Validation

- A real PBF fixture from the pinned scanner dependency was truncated after 5,000,000 bytes. Direct scanning confirmed that it decodes 4,130 ways before returning `unexpected EOF`, so the failure occurs after a meaningful prefix rather than at file open or header parsing.
- The generator, existing-output, CLI, and publication-script differentials above were reproduced on base `68813e05b4db68764b7d9dbb73b7998726223c45` and passed on exact head `76502e637ef8760e24ad2d3c9f03fd318056b2c4` in Go 1.25.1 linux/amd64. The full fixture SHA-256 is `71CE7BD152D68CB9BDB11D9DE4548DB86D103F664BB8620A210DDEE433534647`.
- Exact head passed `go test ./...`, `go vet ./...`, `go build ./...`, the focused scanner/error regressions, CLI failure propagation, pipeline call-order verification, Bash syntax validation, and `git diff --check`.
- [FrogAi Build #40](https://github.com/FrogAi/mapd/actions/runs/31301271067) ran the branch `make build` path for the exact head commit.

## Compatibility and scope

- No API, schema, generated binding, tile-format, setting, or dependency changes.
- Clean EOF remains successful because the scanner reports no error for that case.
- Any nonzero `mapd generate` result now stops this publication script before compression/upload; failures in the script's other commands retain their existing behavior.
- The output root may already exist or be created before scanning. Scanner failure does not create, overwrite, remove, or repair tile files.
- This does not make later filesystem writes or the full multi-region generation job transactional, detect a cleanly terminated but semantically incomplete dataset, or change retry/resume behavior.
- The separate `--input-file` and generated-cell issues are unchanged.
