### PR TITLE
Route interactive commands through mapdCli

### DIFF
--- a/cli/main_menu.go
+++ b/cli/main_menu.go
@@ -65,7 +65,7 @@ func initialModel() uiModel {
 	}
 
 	listDelegate := list.NewDefaultDelegate()
-	pub := cereal.NewPublisher("mapdIn", cereal.MapdInCreator)
+	pub := cereal.NewPublisher("mapdCli", cereal.MapdInCreator)
 	sub := cereal.NewSubscriber("mapdOut", cereal.MapdOutReader, true, false)
 	extendedSub := cereal.NewSubscriber("mapdExtendedOut", cereal.MapdExtendedOutReader, true, false)
 	m := uiModel{list: list.New(items, listDelegate, 0, 0), settings: getSettingsModel(), pub: &pub, sub: &sub, extendedSub: &extendedSub, download: getDownloadModel()}


### PR DESCRIPTION
## Summary

- Publish interactive TUI commands on the daemon's reserved `mapdCli` queue.
- Preserve an existing external gomsgq `mapdIn` publisher when the TUI starts.
- Reuse the existing `MapdIn` payload reader and settings handler on the dedicated command route.

## Motivation

The daemon already separates its inputs: external integrations publish `MapdIn` messages on `mapdIn`, while the daemon reserves and subscribes to `mapdCli` for local interactive commands. The TUI currently constructs its publisher on `mapdIn` instead.

Pinned `gomsgq v0.1.10` enforces a single active writer UID. Initializing a publisher overwrites that UID, resets the write pointer and reader registrations, and invalidates existing readers. A displaced gomsgq publisher panics on its next send.

Because the TUI creates its publisher while constructing the initial model, simply launching `mapd interactive` takes gomsgq writer ownership from an existing `mapdIn` publisher before the user selects or sends any command.

This is also a regression from the original queue design. Commit `2b3c0abe` introduced `GetMapdCliPub`, routed the TUI through it, and added the daemon's `mapdCli` subscriber. The later generic cereal refactor `9ed138395` replaced the helper with `NewPublisher("mapdIn", ...)` while retaining the dedicated subscriber.

## Implementation

The TUI publisher now opens `mapdCli`. The publisher type, `MapdIn` message creator, every settings/download command payload, and every send site remain unchanged.

The daemon already subscribes to `mapdCli` with `MapdInReader` and passes successful messages to the same `Settings.Handle` path used by `mapdIn`, so no receiving-side or schema change is needed.

## Behavior

| Case | Base `68813e05` | This change |
|---|---|---|
| Launch interactive TUI while a gomsgq `mapdIn` publisher exists | TUI replaces the external writer UID | External writer remains active |
| Existing `mapdIn` publisher sends after TUI startup | Panics as an inactive publisher | Sends normally |
| TUI sends `saveSettings` | Publishes on external `mapdIn` | Publishes on reserved `mapdCli` |
| Daemon command handling | Reads both queues through `MapdInReader` | Unchanged |

## Validation

External Linux validation ran the real queue and TUI initialization paths in three simultaneously live helper processes with distinct PIDs and a unique `OPENPILOT_PREFIX`, isolating their shared-memory files from normal queue names:

- Established an active gomsgq `mapdIn` publisher and daemon-style `mapdIn` and `mapdCli` subscribers in separate processes before constructing the TUI model in a third process.
- Base `68813e05` failed: TUI startup displaced the existing publisher, its next `mapdIn` send panicked, and the TUI `saveSettings` command did not appear on `mapdCli`.
- The candidate passed: the existing publisher sent `setExternalSpeedLimit=17` through `mapdIn`, and the TUI sent `saveSettings` through `mapdCli`.
- Repeated the complete focused oracle ten times under the race detector; all repetitions passed.
- `go test ./...`, `go test -race ./...`, `go vet ./...`, and `go build ./...` passed on Linux/amd64 with Go 1.25.1.
- FrogAi Actions [Build #46](https://github.com/FrogAi/mapd/actions/runs/31309539104) ran the branch `make build` path successfully for exact commit `69e3eaf`.

## Compatibility

- The CLI command payloads, command types, settings behavior, download behavior, queue sizes, schemas, public `mapdIn` integration, and output subscriptions are unchanged.
- `mapdCli` already exists in the queue-size table and daemon subscriber lifecycle; this change restores the TUI side of that existing route.
- No dependencies, exported APIs, file formats, or configuration keys change.
- Publisher initialization resets subscriber registration on its own queue. The daemon polling loop re-registers its `mapdCli` subscriber; the oracle exercises that poll before the human-driven TUI command. This PR does not redesign gomsgq publisher startup.
- Multiple concurrent TUI instances can still contend for `mapdCli`. This PR separates local commands from the external `mapdIn` owner rather than adding multi-publisher support.
- The ownership failure and recovery were executed against pinned gomsgq. Native openpilot msgq publisher behavior was not exercised, so an identical native failure mode is not claimed.

## Audit follow-up

An independent audit reproduced both halves of the base failure and confirmed the fix, with one framing correction: on base, `saveSettings` **did** reach the daemon over `mapdIn` and was handled. The base defect is that the TUI's publisher startup de-registers the existing publisher, so the *external* publisher dies and its next send panics — not that the TUI command was lost. Read "Base failed" as "the daemon's publisher was displaced", not "the setting was not saved".

Separately, and pre-existing: a brief dropped-command window remains at TUI startup, because publisher registration transiently de-registers the daemon's subscriber.
