### PR TITLE
Populate download cancellation output

### DIFF
--- a/extended_state.go
+++ b/extended_state.go
@@ -119,6 +119,7 @@ func (s *ExtendedState) setDownloadProgress(out custom.MapdExtendedOut) {
 		panic(err)
 	}
 	p.SetActive(s.DownloadProgress.Active)
+	p.SetCancelled(s.DownloadProgress.Canceled)
 	p.SetTotalFiles(uint32(s.DownloadProgress.TotalFiles))
 	p.SetDownloadedFiles(uint32(s.DownloadProgress.DownloadedFiles))
 	l, err := p.NewLocations(int32(len(s.DownloadProgress.LocationsToDownload)))


### PR DESCRIPTION
## Summary

- Populate the existing `mapdExtendedOut.downloadProgress.cancelled` field.
- Map the internal `DownloadProgress.Canceled` state through the generated serializer.
- Leave download lifecycle, queueing, and cancellation behavior unchanged.

## Motivation

The download owner already records cancellation in `settings.DownloadProgress.Canceled`, and main transfers progress snapshots into `ExtendedState`. The public `MapdDownloadProgress` schema defines `cancelled`, its generated accessor already exists, and the output documentation and CLI use that field.

`ExtendedState.setDownloadProgress` copies the active state, totals, locations, and per-location details but never copies cancellation. Even when `ExtendedState` holds a canceled terminal snapshot, the serialized field remains at its default false value.

## Implementation

The serializer now calls `SetCancelled` with `s.DownloadProgress.Canceled` beside the existing `SetActive` call.

The internal American spelling and public British spelling remain unchanged; this is the missing mapping between their existing contracts.

## Behavior

| Snapshot | Base `68813e05` | This change |
|---|---|---|
| Active and not canceled | `active=true`, `cancelled=false` | Unchanged |
| Terminal and canceled | `active=false`, `cancelled=false` | `active=false`, `cancelled=true` |
| Counts, locations, and location details | Populated | Unchanged |

## Validation

An external Linux oracle constructed the real extended-output struct, invoked `ExtendedState.setDownloadProgress`, marshaled and unmarshaled the Cap'n Proto message, and read the result through generated accessors.

- Base `68813e05` failed because a terminal snapshot with `Canceled=true` serialized `cancelled=false`.
- The candidate preserved active-state semantics and serialized the terminal cancellation state correctly.
- Total/downloaded counts, the location list, and per-location details remained unchanged.
- The focused oracle passed ten repetitions under the race detector.
- `go test ./...`, `go test -race ./...`, `go vet ./...`, and `go build ./...` passed on Linux/amd64 with Go 1.25.1.
- FrogAi Actions [Build #48](https://github.com/FrogAi/mapd/actions/runs/31310843244) ran the branch `make build` path successfully for exact commit `5688b97`.

## Compatibility

- The schema field, ordinal, type ID, generated accessors, event union, queue, documentation, and CLI reader already exist and are unchanged.
- Existing consumers that ignore `cancelled` are unaffected. Consumers that read it receive the state already held by `ExtendedState`.
- PR #107 separately owns terminal-progress retention and request cancellation. It does not modify `extended_state.go`, so this serializer correction does not duplicate or conflict with that lifecycle change.
- No download scheduling, HTTP, archive, progress-channel, message-frequency, configuration, exported API, or file-format behavior changes.

## Audit follow-up — this line has no observable effect until #107 lands

An independent audit confirmed the added line is correct and sets the right field from the right source, but found that the Behavior table describes the **serializer boundary rather than what a fork actually receives on current `main`**.

`Canceled=true` appears only in the terminal progress snapshot, which is delivered through a non-blocking send into a capacity-1 channel polled once per 50 ms — and that terminal snapshot is virtually always dropped. Measured on current `main`: **0 of 30 runs published `cancelled=true`**; what is actually published is `active=true, cancelled=false`. The table holds given such a snapshot, and that was reproduced, but the snapshot does not arrive.

[PR #107](https://github.com/pfeiferj/mapd/pull/107) is what makes this work: its `publishProgress()` evicts the stale capacity-1 entry before re-sending, so the terminal canceled snapshot actually reaches `ExtendedState`. The file-level independence claim is accurate — #107 does not touch `extended_state.go` — but the dependency is behavioral, so **land #107 first or alongside this one**; by itself, this publishes a field that stays false. Composition with #106 and with #107 was verified by trial merge, build, and test.
