### PR TITLE
Honor the configured generator input file

### DIFF
--- a/cli/cli.go
+++ b/cli/cli.go
@@ -87,7 +87,7 @@ func Handle() {
 						Value: false,
 					},
 				},
-				Usage: "Triggers a generation of map data from 'map.osm.pbf'",
+				Usage: "Triggers a generation of map data from the pbf given by --input-file",
 				Action: func(ctx context.Context, cmd *cli.Command) error {
 					offlineSettings := maps.OfflineSettings{
 						Box: m.Box{

--- a/maps/generate_offline.go
+++ b/maps/generate_offline.go
@@ -109,7 +109,7 @@ func generateAreas() []Area {
 func GenerateOffline(s OfflineSettings) {
 	slog.Info("Generating Offline Map")
 	EnsureOfflineMapsDirectories(s)
-	file, err := os.Open("./map.osm.pbf")
+	file, err := os.Open(s.InputFile)
 	if err != nil {
 		slog.Error("could not open map pbf file", "error", err)
 		panic("failed to read maps, exiting")


### PR DESCRIPTION
## Summary

- Open the PBF path provided through `OfflineSettings.InputFile`.
- Make `mapd generate --input-file PATH` select `PATH` instead of the hard-coded default.
- Preserve the existing `./map.osm.pbf` CLI default.

## Motivation

The generate command declares `--input-file`, defaults it to `./map.osm.pbf`, and copies the parsed value into `OfflineSettings.InputFile`. `GenerateOffline` ignores that field and always opens the literal `./map.osm.pbf`.

As a result, an explicit absolute or relative input works only when the default file also exists, and generation reads the default rather than the selected file. Conversely, a missing selected path is silently ignored when the default exists.

## Implementation

`GenerateOffline` now passes `s.InputFile` to `os.Open`. The selected file then follows the existing scanner, generation, and error paths unchanged.

The CLI remains the owner of the default value, so omitting `--input-file` still supplies `./map.osm.pbf`.

## Behavior

| Case | Base `68813e05` | This change |
|---|---|---|
| Absolute selected file exists; default absent | Panics opening default | Generates from selected file |
| Relative selected file exists; default absent | Panics opening default | Generates from selected file |
| Selected file missing; default exists | Generates from default | Existing open-error panic |
| Selected path empty; default exists | Generates from default | Existing open-error panic |
| `--input-file` omitted; default exists | Generates from default | Unchanged |

## Validation

An external Linux oracle exercised the exported generator and a built CLI child process with a real locations-on-ways PBF fixture. Every successful case decoded the generated packed Cap'n Proto output and required one loaded tile containing ways.

- Base `68813e05` ignored absolute, relative, missing, and empty selections; the explicit CLI selection failed when no default file existed.
- The candidate used absolute and relative paths, rejected missing and empty selected paths through the existing open-error policy, and preserved direct and CLI default behavior.
- The complete focused matrix passed three repetitions under the race detector.
- `go test ./...`, `go test -race ./...`, `go vet ./...`, and `go build ./...` passed on Linux/amd64 with Go 1.25.1.
- FrogAi Actions [Build #49](https://github.com/FrogAi/mapd/actions/runs/31311655472) passed the exact commit `135f703f449f9227477aca978258abf7ae0afa56`; the branch-push workflow ran its `Build binary` step.

## Compatibility

- The CLI flag, alias, default, help text, settings field, output layout, scripts, and generated tile format are unchanged.
- Relative paths remain relative to the current working directory; absolute paths remain supported by `os.Open`.
- Missing and empty paths retain the existing log-and-panic error policy. Direct Go callers that leave `OfflineSettings.InputFile` empty must now provide the same explicit default that the CLI already supplies.
- PBF scanner-error handling remains the separate scope of PR #111.
- No dependencies, exported APIs, schemas, configuration keys, or file formats change.

## Audit follow-up (head `92bfb64`)

An independent audit confirmed the flag was genuinely dead — base hardcoded `./map.osm.pbf` and silently ignored `--input-file`/`-i` — and that the default path is byte-identical to base behavior.

It also found that this change leaves the `generate` subcommand's own usage line stale, since it still advertised generation "from 'map.osm.pbf'" while the source is now configurable. Head `92bfb64` updates that text to refer to `--input-file`. [FrogAi Build #54](https://github.com/FrogAi/mapd/actions/runs/31320253787) passed for the exact head.

Pre-existing and not addressed here: an input path that opens but cannot be parsed — a directory, or a truncated pbf — still produces zero-way tiles over the requested bounds instead of failing loudly. That behavior is unchanged by this PR, but it becomes easier to reach now that the path is user-supplied.

Composition with [#97](https://github.com/pfeiferj/mapd/pull/97) is clean, verified by trial merge, build, and test, with the way-assignment loop byte-identical to `main` and untouched by both PRs.
